### PR TITLE
Bump minimum required version of php-http/httplug to >= 1.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-http/client-common": "^1.8.1",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0",
-        "php-http/httplug": "^1.0",
+        "php-http/httplug": "^1.1",
         "php-http/message": "^1.0",
         "php-http/message-factory": "^1.0",
         "phpdocumentor/reflection-docblock": "^3.0 || ^4.0",


### PR DESCRIPTION
to fix lowest testing in Edge module: https://travis-ci.org/mxr576/apigee-devportal-drupal/jobs/451427969#L652

(This is so weird, the original ^1.0 should allow to install php-http/httplug 1.1.)