### PR TITLE
Retry plugin config key fix.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -311,8 +311,8 @@ class Client implements ClientInterface
         ];
 
         if (null !== $this->retryPluginConfig) {
-            if (!isset($this->retryPluginConfig['decider'])) {
-                $this->retryPluginConfig['decider'] = function (RequestInterface $request, Exception $e) {
+            if (!isset($this->retryPluginConfig['exception_decider'])) {
+                $this->retryPluginConfig['exception_decider'] = function (RequestInterface $request, Exception $e) {
                     // When Oauth authentication is in use retry decider should ignore
                     // OauthAuthenticationException.
                     if (!$e instanceof OauthAuthenticationException) {


### PR DESCRIPTION
Old `decider` and `delay` keys trigger an error: https://github.com/php-http/client-common/commit/c2ed0d6b8264ac461f17cd4235421fec91b1a464#diff-3b8cae5f864cf64a976062d4b8400ac0R58