### PR TITLE
Require minimum 1.9 from php-http/client-common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "fightbulc/moment": "^1.26",
         "league/period": "^3.4",
         "php-http/cache-plugin": "^1.4",
-        "php-http/client-common": "^1.8.1",
+        "php-http/client-common": "^1.9",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0",
         "php-http/httplug": "^1.1",

--- a/src/Client.php
+++ b/src/Client.php
@@ -311,8 +311,8 @@ class Client implements ClientInterface
         ];
 
         if (null !== $this->retryPluginConfig) {
-            if (!isset($this->retryPluginConfig['decider'])) {
-                $this->retryPluginConfig['decider'] = function (RequestInterface $request, Exception $e) {
+            if (!isset($this->retryPluginConfig['exception_decider'])) {
+                $this->retryPluginConfig['exception_decider'] = function (RequestInterface $request, Exception $e) {
                     // When Oauth authentication is in use retry decider should ignore
                     // OauthAuthenticationException.
                     if (!$e instanceof OauthAuthenticationException) {

--- a/tests/Test/OnlineClientBase.php
+++ b/tests/Test/OnlineClientBase.php
@@ -41,7 +41,7 @@ abstract class OnlineClientBase extends Client implements OnlineClientInterface
             Client::CONFIG_USER_AGENT_PREFIX => static::USER_AGENT_PREFIX,
             Client::CONFIG_RETRY_PLUGIN_CONFIG => [
                 'retries' => 5,
-                'decider' => function (RequestInterface $request, Exception $e) {
+                'exception_decider' => function (RequestInterface $request, Exception $e) {
                     // Only retry API calls that failed with this specific error.
                     if ($e instanceof ApiResponseException && 'messaging.adaptors.http.flow.ApplicationNotFound' === $e->getEdgeErrorCode()) {
                         return true;
@@ -49,7 +49,7 @@ abstract class OnlineClientBase extends Client implements OnlineClientInterface
 
                     return false;
                 },
-                'delay' => function (RequestInterface $request, Exception $e, $retries): int {
+                'exception_delay' => function (RequestInterface $request, Exception $e, $retries): int {
                     return $retries * 15000000;
                 },
             ],


### PR DESCRIPTION
Unfortunatelly, thanks to this implementation it is impossible to
support older versions of this library by using old and new array keys
in the same time because if both exists it throws an exception.
https://github.com/php-http/client-common/pull/142