### PR TITLE
The `keepOriginalStartDate` attribute is not always set on rate plan

### DIFF
--- a/src/Api/Monetization/Entity/Property/KeepOriginalStartDatePropertyAwareTrait.php
+++ b/src/Api/Monetization/Entity/Property/KeepOriginalStartDatePropertyAwareTrait.php
@@ -33,7 +33,7 @@ trait KeepOriginalStartDatePropertyAwareTrait
      */
     public function isKeepOriginalStartDate(): bool
     {
-        return $this->keepOriginalStartDate;
+        return ($this->keepOriginalStartDate == true);
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/apigee/apigee-client-php/issues/47