### PR TITLE
[DRUP-662] Allow null to be returned by `isKeepOriginalStartDate`.

### DIFF
--- a/src/Api/Monetization/Entity/Property/KeepOriginalStartDatePropertyAwareTrait.php
+++ b/src/Api/Monetization/Entity/Property/KeepOriginalStartDatePropertyAwareTrait.php
@@ -31,7 +31,7 @@ trait KeepOriginalStartDatePropertyAwareTrait
     /**
      * @inheritdoc
      */
-    public function isKeepOriginalStartDate(): bool
+    public function isKeepOriginalStartDate(): ?bool
     {
         return $this->keepOriginalStartDate;
     }

--- a/src/Api/Monetization/Entity/Property/KeepOriginalStartDatePropertyInterface.php
+++ b/src/Api/Monetization/Entity/Property/KeepOriginalStartDatePropertyInterface.php
@@ -23,7 +23,7 @@ interface KeepOriginalStartDatePropertyInterface
     /**
      * @return bool
      */
-    public function isKeepOriginalStartDate(): bool;
+    public function isKeepOriginalStartDate(): ?bool;
 
     /**
      * @param bool $keepOriginalStartDate


### PR DESCRIPTION
Fixes https://github.com/apigee/apigee-client-php/issues/47
It was agreed that the SDK doesn't have to make a decision on the value if it is not supplied.

Replaces https://github.com/apigee/apigee-client-php/pull/49/files