### PR TITLE
DRUP-801 Add forked AddPathPlugin and removed required patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,9 @@ $ composer require php-http/guzzle6-adapter:^1.1.1
 $ composer require apigee/apigee-client-php
 ```
 
-If you would like to use [OAuth (SAML) authentication](https://docs.apigee.com/api-platform/system-administration/using-oauth2-security-apigee-edge-management-api#usingtheapitogettokens-postrefreshanaccesstoken)
-then you have to install [this patch](https://patch-diff.githubusercontent.com/raw/php-http/client-common/pull/103.diff)
-from [this php-http/client-common pull request](https://github.com/php-http/client-common/pull/103). If you use
-[composer-patches](https://github.com/cweagans/composer-patches) plugin and you [allowed dependencies to apply patches](https://github.com/cweagans/composer-patches#allowing-patches-to-be-applied-from-dependencies)
-then this patch is automatically gets applied when this library is installed.
-
 ## Usage examples
 
 ### Basic API usage
-
 
 ```php
 <?php

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "symfony/serializer": "^3.4 || ^4.0"
     },
     "require-dev": {
-        "cweagans/composer-patches": "^1.6",
         "friendsofphp/php-cs-fixer": "^2.14",
         "fzaninotto/faker": "^1.7",
         "guzzlehttp/psr7": "^1.0",
@@ -82,11 +81,6 @@
     "extra": {
         "branch-alias": {
             "dev-2.x": "2.0.x-dev"
-        },
-        "patches": {
-            "php-http/client-common": {
-                "Path prefix must be present #113": "https://github.com/php-http/client-common/pull/113.diff"
-            }
         }
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,14 +20,15 @@ namespace Apigee\Edge;
 
 use Apigee\Edge\Exception\ApiResponseException;
 use Apigee\Edge\Exception\OauthAuthenticationException;
+use Apigee\Edge\HttpClient\Plugin\AddPathPlugin;
 use Apigee\Edge\HttpClient\Plugin\Authentication\Oauth;
 use Apigee\Edge\HttpClient\Plugin\ResponseHandlerPlugin;
 use Apigee\Edge\HttpClient\Plugin\RetryOauthAuthenticationPlugin;
 use Apigee\Edge\HttpClient\Utility\Builder;
 use Apigee\Edge\HttpClient\Utility\Journal;
 use Apigee\Edge\HttpClient\Utility\JournalInterface;
+use Http\Client\Common\Plugin\AddHostPlugin;
 use Http\Client\Common\Plugin\AuthenticationPlugin;
-use Http\Client\Common\Plugin\BaseUriPlugin;
 use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
 use Http\Client\Common\Plugin\HistoryPlugin;
 use Http\Client\Common\Plugin\RetryPlugin;
@@ -296,7 +297,8 @@ class Client implements ClientInterface
     {
         // Alters requests, adds base path and authentication.
         $firstPlugins = [
-            new BaseUriPlugin($this->getBaseUri(), ['replace' => true]),
+            new AddHostPlugin($this->getBaseUri(), ['replace' => true]),
+            new AddPathPlugin($this->getBaseUri()),
             new HeaderDefaultsPlugin($this->getDefaultHeaders()),
         ];
 

--- a/src/HttpClient/Plugin/AddPathPlugin.php
+++ b/src/HttpClient/Plugin/AddPathPlugin.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apigee\Edge\HttpClient\Plugin;
+
+use Apigee\Edge\Exception\InvalidArgumentException;
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Forked and customized AddPathPlugin from php-http/client-common:2.x branch.
+ *
+ * There is a long-lasting bug in the php-http/client-common:1.x branch that
+ * has not fixed yet and probably it won't be fixed anytime soon. This is the
+ * reason why we forked the 2.x version of this plugin to this library.
+ *
+ * @see https://github.com/php-http/client-common/blob/2.0.0/src/Plugin/AddPathPlugin.php
+ * @see https://github.com/php-http/client-common/issues/171
+ * @see https://github.com/php-http/client-common/issues/141
+ */
+final class AddPathPlugin implements Plugin
+{
+    /**
+     * The URI.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    private $uri;
+
+    /**
+     * AddPathPlugin constructor.
+     *
+     * @param \Psr\Http\Message\UriInterface $uri
+     *   The URI.
+     */
+    public function __construct(UriInterface $uri)
+    {
+        if ('' === $uri->getPath()) {
+            throw new InvalidArgumentException('URI path cannot be empty');
+        }
+
+        if ('/' === substr($uri->getPath(), -1)) {
+            $uri = $uri->withPath(rtrim($uri->getPath(), '/'));
+        }
+
+        $this->uri = $uri;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        $prepend = $this->uri->getPath();
+        $path = $request->getUri()->getPath();
+
+        if (0 !== strpos($path, $prepend)) {
+            $request = $request->withUri($request->getUri()->withPath($prepend . $path));
+        }
+
+        return $next($request);
+    }
+}

--- a/src/HttpClient/Utility/Builder.php
+++ b/src/HttpClient/Utility/Builder.php
@@ -23,8 +23,6 @@ use Http\Client\Common\Plugin\HeaderAppendPlugin;
 use Http\Client\Common\PluginClient;
 use Http\Client\HttpClient;
 use Http\Discovery\HttpClientDiscovery;
-use Http\Discovery\MessageFactoryDiscovery;
-use Http\Discovery\StreamFactoryDiscovery;
 use Http\Message\RequestFactory;
 use Http\Message\StreamFactory;
 
@@ -40,12 +38,6 @@ class Builder implements BuilderInterface
 
     /** @var PluginClient */
     private $pluginClient;
-
-    /** @var StreamFactory */
-    private $streamFactory;
-
-    /** @var RequestFactory */
-    private $requestFactory;
 
     /** @var array */
     private $headers = [];
@@ -73,8 +65,13 @@ class Builder implements BuilderInterface
         StreamFactory $streamFactory = null
     ) {
         $this->httpClient = $httpClient ?: HttpClientDiscovery::find();
-        $this->requestFactory = $requestFactory ?: MessageFactoryDiscovery::find();
-        $this->streamFactory = $streamFactory ?: StreamFactoryDiscovery::find();
+        if (null !== $requestFactory) {
+            @trigger_error('The $requestFactory parameter is deprecated since version 2.0.3 and will be removed in 3.0.0. Omit the second parameter.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $streamFactory) {
+            @trigger_error('The $streamFactory parameter is deprecated since version 2.0.3 and will be removed in 3.0.0. Omit the second parameter.', E_USER_DEPRECATED);
+        }
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -73,12 +73,14 @@ class ClientTest extends TestCase
      */
     public function testEndpointShouldBeOverridden(Client $client): void
     {
-        $customEndpoint = 'http://example.com';
+        // The Apigee API endpoint URI always contains the API version in path.
+        // @see \Apigee\Edge\HttpClient\Plugin\AddPathPlugin::__construct()
+        $customEndpoint = 'http://example.com/version_1';
         $builder = new Builder(self::$httpClient);
         $client = new Client(new NullAuthentication(), $customEndpoint, [Client::CONFIG_HTTP_CLIENT_BUILDER => $builder]);
-        $client->get('/');
+        $client->get('');
         $sent_request = self::$httpClient->getLastRequest();
-        $this->assertEquals($customEndpoint, "{$sent_request->getUri()->getScheme()}://{$sent_request->getUri()->getHost()}");
+        $this->assertEquals($client->getUriFactory()->createUri($customEndpoint)->getHost(), $sent_request->getUri()->getHost());
     }
 
     public function testUserAgentShouldBeOverridden(): void


### PR DESCRIPTION
README.md contained a reference to an outdated required patch (103)
for php-http/client-common:1.x. The composer.json contained the correct
reference (113). Although, that patch also became outdated because it
did not contain a bulletproof fix for the problem.
The issue has been properly fixed in the 2.x branch. This is the reason
why we forked the fixed version from the 2.x branch and with that
also removed all the overhead caused by conditional patching the
php-http/client-common dependency.

php-http/client-common#171

TODO:
* Update also outdated documentation on [Drupal.org](https://www.drupal.org/docs/8/modules/apigee-edge/configure-the-connection-to-apigee-edge#configuring-oauth2-authentication-for-apigee-edge) (and other places?) cc @llynch00