### PR TITLE
[#81] Remove header_comment validation.

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,27 +1,16 @@
 <?php
 
-$header = <<<HEADER
-Copyright 2018 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-                           
-     https://www.apache.org/licenses/LICENSE-2.0
-                           
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-HEADER;
-
 $finder = PhpCsFixer\Finder::create()
     ->files()
     ->name('*.php')
     ->name('*.inc')
     ->in([__DIR__ . '/examples', __DIR__ . '/src', __DIR__ . '/tests']);
 
+/**
+ * The 'header_comment' validation was removed because the copyright year needs to be pinned to the year the file was
+ * added to the repo.
+ * @todo: Add a copyright validation (https://github.com/apigee/apigee-client-php/issues/81).
+ */
 return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
     ->setRules([
@@ -30,7 +19,6 @@ return PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'class_definition' => ['singleLine' => false, 'singleItemSingleLine' => true],
         'concat_space' => ['spacing' => 'one'],
-        'header_comment' => ['header' => $header],
         'general_phpdoc_annotation_remove' => ['author'],
         'ordered_class_elements' => true,
         'ordered_imports' => true,


### PR DESCRIPTION
This PR removes the `header_comment` validation because of the reasons explained in https://github.com/apigee/apigee-client-php/issues/79#issuecomment-548592357.

Related to #81 .