### PR TITLE
[#66] Changing criteria to check if pagination is enabled.

### DIFF
--- a/src/Controller/PaginationHelperTrait.php
+++ b/src/Controller/PaginationHelperTrait.php
@@ -108,7 +108,7 @@ trait PaginationHelperTrait
         /** @var \Apigee\Edge\Api\Management\Entity\OrganizationInterface $organization */
         $organization = $this->getOrganizationController()->load($this->getOrganisationName());
 
-        if (OrganizationFeatures::isPaginationEnabled($organization)) {
+        if (OrganizationFeatures::isPaginationAvailable($organization)) {
             return $this->listEntitiesWithCps($pager, $query_params, $key_provider);
         } else {
             $this->triggerCpsSimulationNotice($pager);

--- a/src/Controller/PaginationHelperTrait.php
+++ b/src/Controller/PaginationHelperTrait.php
@@ -108,7 +108,7 @@ trait PaginationHelperTrait
         /** @var \Apigee\Edge\Api\Management\Entity\OrganizationInterface $organization */
         $organization = $this->getOrganizationController()->load($this->getOrganisationName());
 
-        if (OrganizationFeatures::isCpsEnabled($organization)) {
+        if (OrganizationFeatures::isPaginationEnabled($organization)) {
             return $this->listEntitiesWithCps($pager, $query_params, $key_provider);
         } else {
             $this->triggerCpsSimulationNotice($pager);

--- a/src/Utility/OrganizationFeatures.php
+++ b/src/Utility/OrganizationFeatures.php
@@ -35,6 +35,18 @@ final class OrganizationFeatures
     }
 
     /**
+     * Checks whether pagination is enabled on an organization.
+     *
+     * @param \Apigee\Edge\Api\Management\Entity\OrganizationInterface $org
+     *
+     * @return bool
+     */
+    public static function isPaginationEnabled(OrganizationInterface $org): bool
+    {
+        return static::isCpsEnabled($org) || static::isHybridEnabled($org);
+    }
+
+    /**
      * Checks whether hybrid feature is enabled on an organization.
      *
      * @param \Apigee\Edge\Api\Management\Entity\OrganizationInterface $org

--- a/src/Utility/OrganizationFeatures.php
+++ b/src/Utility/OrganizationFeatures.php
@@ -41,7 +41,7 @@ final class OrganizationFeatures
      *
      * @return bool
      */
-    public static function isPaginationEnabled(OrganizationInterface $org): bool
+    public static function isPaginationAvailable(OrganizationInterface $org): bool
     {
         return static::isCpsEnabled($org) || static::isHybridEnabled($org);
     }

--- a/tests/Utility/OrganizationFeaturesTest.php
+++ b/tests/Utility/OrganizationFeaturesTest.php
@@ -30,6 +30,8 @@ use PHPUnit\Framework\TestCase;
 class OrganizationFeaturesTest extends TestCase
 {
     /**
+     * Tests simple properties on the organization.
+     *
      * @dataProvider featurePropertyValueProvider
      */
     public function testOrganizationFeatures(?string $propertyValue, bool $expectedResult): void
@@ -40,6 +42,34 @@ class OrganizationFeaturesTest extends TestCase
         $this->assertEquals($expectedResult, OrganizationFeatures::isCpsEnabled($organization));
         $this->assertEquals($expectedResult, OrganizationFeatures::isHybridEnabled($organization));
         $this->assertEquals($expectedResult, OrganizationFeatures::isMonetizationEnabled($organization));
+    }
+
+    /**
+     * Test if an organization has pagination enabled.
+     */
+    public function testPaginationEnabled(): void
+    {
+        /** @var \Apigee\Edge\Api\Management\Entity\OrganizationInterface $organization */
+        $organization = $this->getMockBuilder(OrganizationInterface::class)->getMock();
+        $organization->method('getPropertyValue')->will($this->returnValueMap([
+            ['features.isCpsEnabled', null],
+            ['features.hybrid.enabled', 'true'],
+        ]));
+        $this->assertTrue(OrganizationFeatures::isPaginationEnabled($organization));
+
+        $organization = $this->getMockBuilder(OrganizationInterface::class)->getMock();
+        $organization->method('getPropertyValue')->will($this->returnValueMap([
+            ['features.isCpsEnabled', 'true'],
+            ['features.hybrid.enabled', null],
+        ]));
+        $this->assertTrue(OrganizationFeatures::isPaginationEnabled($organization));
+
+        $organization = $this->getMockBuilder(OrganizationInterface::class)->getMock();
+        $organization->method('getPropertyValue')->will($this->returnValueMap([
+            ['features.isCpsEnabled', 'false'],
+            ['features.hybrid.enabled', null],
+        ]));
+        $this->assertFalse(OrganizationFeatures::isPaginationEnabled($organization));
     }
 
     public function featurePropertyValueProvider(): array

--- a/tests/Utility/OrganizationFeaturesTest.php
+++ b/tests/Utility/OrganizationFeaturesTest.php
@@ -45,39 +45,48 @@ class OrganizationFeaturesTest extends TestCase
     }
 
     /**
-     * Test if an organization has pagination enabled.
+     * Data provider for testOrganizationFeatures().
+     *
+     * @return array
      */
-    public function testPaginationEnabled(): void
-    {
-        /** @var \Apigee\Edge\Api\Management\Entity\OrganizationInterface $organization */
-        $organization = $this->getMockBuilder(OrganizationInterface::class)->getMock();
-        $organization->method('getPropertyValue')->will($this->returnValueMap([
-            ['features.isCpsEnabled', null],
-            ['features.hybrid.enabled', 'true'],
-        ]));
-        $this->assertTrue(OrganizationFeatures::isPaginationEnabled($organization));
-
-        $organization = $this->getMockBuilder(OrganizationInterface::class)->getMock();
-        $organization->method('getPropertyValue')->will($this->returnValueMap([
-            ['features.isCpsEnabled', 'true'],
-            ['features.hybrid.enabled', null],
-        ]));
-        $this->assertTrue(OrganizationFeatures::isPaginationEnabled($organization));
-
-        $organization = $this->getMockBuilder(OrganizationInterface::class)->getMock();
-        $organization->method('getPropertyValue')->will($this->returnValueMap([
-            ['features.isCpsEnabled', 'false'],
-            ['features.hybrid.enabled', null],
-        ]));
-        $this->assertFalse(OrganizationFeatures::isPaginationEnabled($organization));
-    }
-
     public function featurePropertyValueProvider(): array
     {
         return [
             [null, false],
             ['true', true],
             ['false', false],
+        ];
+    }
+
+    /**
+     * Test if an organization has pagination available.
+     *
+     * @dataProvider paginationAvailableValueProvider
+     */
+    public function testPaginationAvailable($isCpsEnabled, $isHybridEnabled, $expected, $message): void
+    {
+        /** @var \Apigee\Edge\Api\Management\Entity\OrganizationInterface $organization */
+        $organization = $this->getMockBuilder(OrganizationInterface::class)->getMock();
+        $organization->method('getPropertyValue')->will($this->returnValueMap([
+            ['features.isCpsEnabled', $isCpsEnabled],
+            ['features.hybrid.enabled', $isHybridEnabled],
+        ]));
+        $this->assertEquals($expected, OrganizationFeatures::isPaginationAvailable($organization), $message);
+    }
+
+    /**
+     * Data provider for testPaginationAvailable().
+     *
+     * The format for each data set is: [$isCpsEnabled, $isHybridEnabled, $expected, $message]
+     *
+     * @return array
+     */
+    public function paginationAvailableValueProvider(): array
+    {
+        return [
+            [null, 'true', true, 'Hybrid orgs should have pagination.'],
+            ['true', null, true, 'CPS enabled orgs should have pagination.'],
+            ['false', null, false, 'Non-Hybrid org without CPS should not have pagination.'],
         ];
     }
 }


### PR DESCRIPTION
Resolves #66 . Adds helper `OrganizationFeatures::isPaginationEnabled()` method to decide if pagination should be used for an org.