### PR TITLE
[#67] Hybrid compatibility with "expand=false".

### DIFF
--- a/src/Api/Management/Controller/AttributesAwareEntityControllerTrait.php
+++ b/src/Api/Management/Controller/AttributesAwareEntityControllerTrait.php
@@ -140,5 +140,5 @@ trait AttributesAwareEntityControllerTrait
     /**
      * @inheritdoc
      */
-    abstract protected function responseToArray(ResponseInterface $response): array;
+    abstract protected function responseToArray(ResponseInterface $response, bool $expandCompatibility = false): array;
 }

--- a/src/Api/Monetization/Controller/ListingHelperTrait.php
+++ b/src/Api/Monetization/Controller/ListingHelperTrait.php
@@ -49,7 +49,7 @@ trait ListingHelperTrait
         return reset($responseArray);
     }
 
-    abstract protected function responseToArray(ResponseInterface $response): array;
+    abstract protected function responseToArray(ResponseInterface $response, bool $expandCompatibility = false): array;
 
     abstract protected function responseArrayToArrayOfEntities(array $responseArray, string $keyGetter = 'id'): array;
 }

--- a/src/Controller/NonPaginatedEntityIdListingControllerTrait.php
+++ b/src/Controller/NonPaginatedEntityIdListingControllerTrait.php
@@ -18,6 +18,7 @@
 
 namespace Apigee\Edge\Controller;
 
+use Apigee\Edge\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -40,8 +41,9 @@ trait NonPaginatedEntityIdListingControllerTrait
         ];
         $uri = $this->getBaseEndpointUri()->withQuery(http_build_query($query_params));
         $response = $this->getClient()->get($uri);
+        $expandCompatibility = (ClientInterface::HYBRID_ENDPOINT == $this->getClient()->getEndpoint());
 
-        return $this->responseToArray($response);
+        return $this->responseToArray($response, $expandCompatibility);
     }
 
     /**

--- a/src/Controller/NonPaginatedEntityIdListingControllerTrait.php
+++ b/src/Controller/NonPaginatedEntityIdListingControllerTrait.php
@@ -41,7 +41,7 @@ trait NonPaginatedEntityIdListingControllerTrait
         ];
         $uri = $this->getBaseEndpointUri()->withQuery(http_build_query($query_params));
         $response = $this->getClient()->get($uri);
-        $expandCompatibility = (ClientInterface::HYBRID_ENDPOINT == $this->getClient()->getEndpoint());
+        $expandCompatibility = (ClientInterface::HYBRID_ENDPOINT === $this->getClient()->getEndpoint());
 
         return $this->responseToArray($response, $expandCompatibility);
     }

--- a/src/Controller/NonPaginatedEntityIdListingControllerTrait.php
+++ b/src/Controller/NonPaginatedEntityIdListingControllerTrait.php
@@ -49,5 +49,5 @@ trait NonPaginatedEntityIdListingControllerTrait
     /**
      * @inheritdoc
      */
-    abstract protected function responseToArray(ResponseInterface $response): array;
+    abstract protected function responseToArray(ResponseInterface $response, bool $expandCompatibility = false): array;
 }

--- a/src/Controller/NonPaginatedEntityListingControllerTrait.php
+++ b/src/Controller/NonPaginatedEntityListingControllerTrait.php
@@ -50,7 +50,7 @@ trait NonPaginatedEntityListingControllerTrait
     /**
      * @inheritdoc
      */
-    abstract protected function responseToArray(ResponseInterface $response): array;
+    abstract protected function responseToArray(ResponseInterface $response, bool $expandCompatibility = false): array;
 
     /**
      * @inheritdoc

--- a/src/Controller/PaginationHelperTrait.php
+++ b/src/Controller/PaginationHelperTrait.php
@@ -318,7 +318,7 @@ trait PaginationHelperTrait
         $query_params = [
                 'expand' => 'false',
             ] + $query_params;
-        $expandCompatibility = (ClientInterface::HYBRID_ENDPOINT == $this->getClient()->getEndpoint());
+        $expandCompatibility = (ClientInterface::HYBRID_ENDPOINT === $this->getClient()->getEndpoint());
         if ($pager) {
             return $this->getResultsInRange($pager, $query_params, $expandCompatibility);
         } else {
@@ -366,7 +366,7 @@ trait PaginationHelperTrait
 
         $uri = $this->getBaseEndpointUri()->withQuery(http_build_query($query_params));
         $response = $this->getClient()->get($uri);
-        $expandCompatibility = (ClientInterface::HYBRID_ENDPOINT == $this->getClient()->getEndpoint());
+        $expandCompatibility = (ClientInterface::HYBRID_ENDPOINT === $this->getClient()->getEndpoint());
 
         $ids = $this->responseToArray($response, $expandCompatibility);
 

--- a/src/Utility/ResponseToArrayHelper.php
+++ b/src/Utility/ResponseToArrayHelper.php
@@ -55,12 +55,7 @@ trait ResponseToArrayHelper
                 $decoded = (array) $this->jsonDecoder()->decode((string) $response->getBody(), 'json');
 
                 if ($expandCompatibility) {
-                    $root = reset($decoded);
-                    $decoded = [];
-                    foreach ($root as $item) {
-                        $item = (array) $item;
-                        $decoded[] = reset($item);
-                    }
+                    $decoded = $this->normalizeExpandFalseForHybrid($decoded);
                 }
 
                 return $decoded;
@@ -77,5 +72,29 @@ trait ResponseToArrayHelper
             $this->getClient()->getJournal()->getLastRequest(),
             sprintf('Unable to parse response with %s type. Response body: %s', $response->getHeaderLine('Content-Type') ?: 'unknown', (string) $response->getBody())
         );
+    }
+
+    /**
+     * Helper method to normalize a Hybrid response.
+     *
+     * @see ResponseToArrayHelper::responseToArray()
+     *
+     * @param array $responseArray
+     *   The decoded response array.
+     *
+     * @return array
+     *   The response array normalized.
+     */
+    protected function normalizeExpandFalseForHybrid(array $responseArray): array
+    {
+        // Ignore entity type key from response, ex.: apiProduct.
+        $responseArray = reset($responseArray);
+
+        // Return an array with the value of the first property of each item.
+        return array_map(function ($item) {
+            $item = (array) $item;
+
+            return reset($item);
+        }, $responseArray);
     }
 }

--- a/src/Utility/ResponseToArrayHelper.php
+++ b/src/Utility/ResponseToArrayHelper.php
@@ -34,18 +34,36 @@ trait ResponseToArrayHelper
      * The SDK only works with JSON responses, but let's be prepared for the unexpected.
      *
      * @param \Psr\Http\Message\ResponseInterface $response
+     * @param bool $expandCompatability
+     *   If the API response requires backwards compatibility with the way Edge
+     *   formats it's responses.
+     *
+     * @see For reference on $expandCompatability, see the structure of
+     *   expand=false query parameter on the Hybrid documentation:
+     *   https://docs.apigee.com/hybrid/beta2/reference/apis/unsupported-apis
      *
      * @throws \RuntimeException If response can not be decoded, because the input format is unknown.
      * @throws \Apigee\Edge\Exception\InvalidJsonException If there was an error with decoding a JSON response.
      *
      * @return array
      */
-    protected function responseToArray(ResponseInterface $response): array
+    protected function responseToArray(ResponseInterface $response, bool $expandCompatibility = false): array
     {
         if ($response->getHeaderLine('Content-Type') &&
             0 === strpos($response->getHeaderLine('Content-Type'), 'application/json')) {
             try {
-                return (array) $this->jsonDecoder()->decode((string) $response->getBody(), 'json');
+                $decoded = (array) $this->jsonDecoder()->decode((string) $response->getBody(), 'json');
+
+                if ($expandCompatibility) {
+                    $root = reset($decoded);
+                    $decoded = [];
+                    foreach ($root as $item) {
+                        $item = (array) $item;
+                        $decoded[] = reset($item);
+                    }
+                }
+
+                return $decoded;
             } catch (\UnexpectedValueException $e) {
                 throw new InvalidJsonException(
                     $e->getMessage(),

--- a/tests/Test/Utility/ResponseToArrayHelper.php
+++ b/tests/Test/Utility/ResponseToArrayHelper.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apigee\Edge\Tests\Test\Utility;
+
+use Apigee\Edge\ClientInterface;
+use Apigee\Edge\Tests\Test\Controller\MockClientAwareTrait;
+use Apigee\Edge\Utility\ResponseToArrayHelper as ResponseToArray;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+
+/**
+ * Class ResponseToArrayHelper.
+ */
+class ResponseToArrayHelper
+{
+    use ResponseToArray;
+    use MockClientAwareTrait;
+
+    public function convertResponseToArray(ResponseInterface $response, bool $expandCompatibility = false): array
+    {
+        return $this->responseToArray($response, $expandCompatibility);
+    }
+
+    protected function jsonDecoder(): JsonDecode
+    {
+        return new JsonDecode();
+    }
+
+    protected function getClient(): ClientInterface
+    {
+        return static::mockApiClient();
+    }
+}

--- a/tests/Utility/ResponseToArrayHelperTest.php
+++ b/tests/Utility/ResponseToArrayHelperTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apigee\Edge\Tests\Utility;
+
+use Apigee\Edge\Tests\Test\Utility\ResponseToArrayHelper;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class ResponseToArrayHelperTest.
+ *
+ * @small
+ */
+class ResponseToArrayHelperTest extends TestCase
+{
+    private $responseToArrayHelper;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->responseToArrayHelper = new ResponseToArrayHelper();
+    }
+
+    /**
+     * Tests the expand parameter compatibility.
+     */
+    public function testExpandCompatibility(): void
+    {
+        /** @var \Psr\Http\Message\ResponseInterface $response1 */
+        $response1 = $this->getMockBuilder(ResponseInterface::class)->getMock();
+        $response1->method('getHeaderLine')->willReturn('application/json');
+        $response1->method('getBody')->willReturn('["helloworld","weather"]');
+        $decodedEdgeStyle = $this->responseToArrayHelper->convertResponseToArray($response1, false);
+
+        /** @var \Psr\Http\Message\ResponseInterface $response2 */
+        $response2 = $this->getMockBuilder(ResponseInterface::class)->getMock();
+        $response2->method('getHeaderLine')->willReturn('application/json');
+        $response2->method('getBody')->willReturn('{"proxies":[{"name":"helloworld"},{"name":"weather"}]}');
+        $decodedWithCompatibility = $this->responseToArrayHelper->convertResponseToArray($response2, true);
+
+        $this->assertEquals($decodedEdgeStyle, $decodedWithCompatibility);
+    }
+}


### PR DESCRIPTION
Resolves #67. Hybrid returns a different response when using "expand=false": 
```
{
  "proxies": [
    {
      "name": "helloworld"
    },
    {
      "name": "weather"
    }
  ]
}
```
While current Edge returns: 
```
[
  "helloworld",
  "weather"
]
```

This PR formats Hybrid responses in a compatible way.