### PR TITLE
[#86] Encode parameters in entity endpoint URIs.

### DIFF
--- a/src/Api/Management/Controller/AppCredentialController.php
+++ b/src/Api/Management/Controller/AppCredentialController.php
@@ -124,6 +124,7 @@ abstract class AppCredentialController extends EntityController implements AppCr
      */
     public function setApiProductStatus(string $consumerKey, string $apiProduct, string $status): void
     {
+        $apiProduct = rawurlencode($apiProduct);
         $uri = $this->getBaseEndpointUri()
             ->withPath("{$this->getBaseEndpointUri()}/keys/{$consumerKey}/apiproducts/{$apiProduct}")
             ->withQuery(http_build_query(['action' => $status]));
@@ -135,6 +136,7 @@ abstract class AppCredentialController extends EntityController implements AppCr
      */
     public function deleteApiProduct(string $consumerKey, string $apiProduct): AppCredentialInterface
     {
+        $apiProduct = rawurlencode($apiProduct);
         $uri = $this->getBaseEndpointUri()->withPath("{$this->getBaseEndpointUri()}/keys/{$consumerKey}/apiproducts/{$apiProduct}");
         $response = $this->client->delete($uri);
 

--- a/src/Api/Management/Controller/AttributesAwareEntityControllerTrait.php
+++ b/src/Api/Management/Controller/AttributesAwareEntityControllerTrait.php
@@ -130,8 +130,9 @@ trait AttributesAwareEntityControllerTrait
      */
     protected function getEntityAttributeUri(string $entityId, string $name): UriInterface
     {
+        $encoded = rawurlencode($name);
         $uri = $this->getEntityAttributesUri($entityId)->withPath(
-            $this->getEntityAttributesUri($entityId) . '/' . $name
+            $this->getEntityAttributesUri($entityId) . '/' . $encoded
         );
 
         return $uri;

--- a/src/Api/Management/Controller/CompanyAppCredentialController.php
+++ b/src/Api/Management/Controller/CompanyAppCredentialController.php
@@ -57,7 +57,9 @@ class CompanyAppCredentialController extends AppCredentialController implements 
      */
     protected function getBaseEndpointUri(): UriInterface
     {
-        return $this->client->getUriFactory()->createUri("/organizations/{$this->organization}/companies/{$this->companyName}/apps/{$this->appName}");
+        $appName = rawurlencode($this->appName);
+
+        return $this->client->getUriFactory()->createUri("/organizations/{$this->organization}/companies/{$this->companyName}/apps/{$appName}");
     }
 
     /**

--- a/src/Api/Management/Controller/CompanyMembersController.php
+++ b/src/Api/Management/Controller/CompanyMembersController.php
@@ -81,7 +81,8 @@ class CompanyMembersController extends AbstractController implements CompanyMemb
      */
     public function removeMember(string $email): void
     {
-        $this->client->delete($this->getBaseEndpointUri()->withPath("{$this->getBaseEndpointUri()->getPath()}/{$email}"));
+        $encoded = rawurlencode($email);
+        $this->client->delete($this->getBaseEndpointUri()->withPath("{$this->getBaseEndpointUri()->getPath()}/{$encoded}"));
     }
 
     /**

--- a/src/Api/Management/Controller/DeveloperAppController.php
+++ b/src/Api/Management/Controller/DeveloperAppController.php
@@ -63,7 +63,9 @@ class DeveloperAppController extends AppByOwnerController implements DeveloperAp
      */
     protected function getBaseEndpointUri(): UriInterface
     {
-        return $this->client->getUriFactory()->createUri("/organizations/{$this->organization}/developers/{$this->developerId}/apps");
+        $developerId = rawurlencode($this->developerId);
+
+        return $this->client->getUriFactory()->createUri("/organizations/{$this->organization}/developers/{$developerId}/apps");
     }
 
     /**

--- a/src/Api/Management/Controller/DeveloperAppCredentialController.php
+++ b/src/Api/Management/Controller/DeveloperAppCredentialController.php
@@ -58,7 +58,10 @@ class DeveloperAppCredentialController extends AppCredentialController implement
      */
     protected function getBaseEndpointUri(): UriInterface
     {
-        return $this->client->getUriFactory()->createUri("/organizations/{$this->organization}/developers/{$this->developerId}/apps/{$this->appName}");
+        $developerId = rawurlencode($this->developerId);
+        $appName = rawurlencode($this->appName);
+
+        return $this->client->getUriFactory()->createUri("/organizations/{$this->organization}/developers/{$developerId}/apps/{$appName}");
     }
 
     /**

--- a/src/Api/Monetization/Controller/ApiPackageController.php
+++ b/src/Api/Monetization/Controller/ApiPackageController.php
@@ -54,6 +54,7 @@ class ApiPackageController extends OrganizationAwareEntityController implements 
      */
     public function deleteProduct(string $apiPackageId, string $productId): void
     {
+        $productId = rawurlencode($productId);
         $this->getClient()->delete(
             $this->getBaseEndpointUri()->withPath("{$this->getBaseEndpointUri()}/{$apiPackageId}/products/{$productId}")
         );
@@ -64,6 +65,7 @@ class ApiPackageController extends OrganizationAwareEntityController implements 
      */
     public function addProduct(string $apiPackageId, string $productId): void
     {
+        $productId = rawurlencode($productId);
         $this->getClient()->post(
             $this->getBaseEndpointUri()->withPath(
                 "{$this->getBaseEndpointUri()}/{$apiPackageId}/products/{$productId}"
@@ -116,6 +118,8 @@ class ApiPackageController extends OrganizationAwareEntityController implements 
 
     private function getAvailableApiPackages(string $type, string $id, bool $active = false, bool $allAvailable = true): array
     {
+        $id = rawurlencode($id);
+
         return $this->listEntities($this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/{$type}/{$id}/monetization-packages")->withQuery(http_build_query([
             'current' => $active ? 'true' : 'false',
             'allAvailable' => $allAvailable ? 'true' : 'false',

--- a/src/Api/Monetization/Controller/ApiProductController.php
+++ b/src/Api/Monetization/Controller/ApiProductController.php
@@ -77,6 +77,7 @@ class ApiProductController extends OrganizationAwareEntityController implements 
      */
     private function getEligibleProducts(string $type, string $entityId): array
     {
+        $entityId = rawurlencode($entityId);
         $products = [];
         foreach ($this->getRawList($this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/{$type}/{$entityId}/eligible-products")) as $item) {
             /** @var \Apigee\Edge\Api\Monetization\Entity\ApiProductInterface $product */

--- a/src/Api/Monetization/Controller/CompanyActiveRatePlanController.php
+++ b/src/Api/Monetization/Controller/CompanyActiveRatePlanController.php
@@ -58,6 +58,8 @@ class CompanyActiveRatePlanController extends ActiveRatePlanController
      */
     protected function getActiveRatePlanForApiProductEndpoint(string $apiProductName): UriInterface
     {
+        $apiProductName = rawurlencode($apiProductName);
+
         return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/companies/{$this->companyName}/products/{$apiProductName}/rate-plan-by-developer-product");
     }
 }

--- a/src/Api/Monetization/Controller/DeveloperAcceptedRatePlanController.php
+++ b/src/Api/Monetization/Controller/DeveloperAcceptedRatePlanController.php
@@ -54,10 +54,11 @@ class DeveloperAcceptedRatePlanController extends AcceptedRatePlanController
     protected function getBaseEndpointUri(): UriInterface
     {
         // For these API endpoint:
+        $developerId = rawurlencode($this->developer);
         // https://apidocs.apigee.com/monetize/apis/post/organizations/%7Borg_name%7D/developers/%7Bdeveloper_or_company_id%7D/developer-rateplans (create)
         // https://apidocs.apigee.com/monetize/apis/put/organizations/%7Borg_name%7D/developers/%7Bdeveloper_id%7D/developer-rateplans/%7Bplan_id%7D (update)
         // https://apidocs.apigee.com/monetize/apis/put/organizations/%7Borg_name%7D/developers/%7Bdeveloper_id%7D/developer-rateplans/%7Bplan_id%7D (load)
-        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$this->developer}/developer-rateplans");
+        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$developerId}/developer-rateplans");
     }
 
     /**
@@ -84,9 +85,10 @@ class DeveloperAcceptedRatePlanController extends AcceptedRatePlanController
      */
     protected function getAcceptedRatePlansEndpoint(): UriInterface
     {
+        $developerId = rawurlencode($this->developer);
         // For this API endpoint:
         // https://apidocs.apigee.com/monetize/apis/get/organizations/%7Borg_name%7D/developers/%7Bdeveloper_id%7D/developer-accepted-rateplans
-        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$this->developer}/developer-accepted-rateplans");
+        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$developerId}/developer-accepted-rateplans");
     }
 
     /**

--- a/src/Api/Monetization/Controller/DeveloperActiveRatePlanController.php
+++ b/src/Api/Monetization/Controller/DeveloperActiveRatePlanController.php
@@ -50,7 +50,9 @@ class DeveloperActiveRatePlanController extends ActiveRatePlanController
      */
     protected function getBaseEndpointUri(): UriInterface
     {
-        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$this->developerId}/developer-rateplans");
+        $developerId = rawurlencode($this->developerId);
+
+        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$developerId}/developer-rateplans");
     }
 
     /**
@@ -58,6 +60,9 @@ class DeveloperActiveRatePlanController extends ActiveRatePlanController
      */
     protected function getActiveRatePlanForApiProductEndpoint(string $apiProductName): UriInterface
     {
-        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$this->developerId}/products/{$apiProductName}/rate-plan-by-developer-product");
+        $developerId = rawurlencode($this->developerId);
+        $apiProductName = rawurlencode($apiProductName);
+
+        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$developerId}/products/{$apiProductName}/rate-plan-by-developer-product");
     }
 }

--- a/src/Api/Monetization/Controller/DeveloperPrepaidBalanceController.php
+++ b/src/Api/Monetization/Controller/DeveloperPrepaidBalanceController.php
@@ -50,7 +50,9 @@ class DeveloperPrepaidBalanceController extends PrepaidBalanceController impleme
      */
     protected function getBaseEndpointUri(): UriInterface
     {
-        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$this->developerId}/developer-balances");
+        $developerId = rawurlencode($this->developerId);
+
+        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$developerId}/developer-balances");
     }
 
     /**
@@ -58,6 +60,8 @@ class DeveloperPrepaidBalanceController extends PrepaidBalanceController impleme
      */
     protected function getPrepaidBalanceEndpoint(): UriInterface
     {
-        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$this->developerId}/prepaid-developer-balance");
+        $developerId = rawurlencode($this->developerId);
+
+        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$developerId}/prepaid-developer-balance");
     }
 }

--- a/src/Api/Monetization/Controller/DeveloperReportDefinitionController.php
+++ b/src/Api/Monetization/Controller/DeveloperReportDefinitionController.php
@@ -50,7 +50,9 @@ class DeveloperReportDefinitionController extends LegalEntityReportDefinitionCon
      */
     protected function getBaseEndpointUri(): UriInterface
     {
-        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$this->developerId}/report-definitions");
+        $developerId = rawurlencode($this->developerId);
+
+        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$developerId}/report-definitions");
     }
 
     /**

--- a/src/Api/Monetization/Controller/DeveloperTermsAndConditionsController.php
+++ b/src/Api/Monetization/Controller/DeveloperTermsAndConditionsController.php
@@ -48,7 +48,9 @@ class DeveloperTermsAndConditionsController extends LegalEntityTermsAndCondition
      */
     protected function getBaseEndpointUri(): UriInterface
     {
-        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$this->developerId}/developer-tncs");
+        $developerId = rawurlencode($this->developerId);
+
+        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$developerId}/developer-tncs");
     }
 
     /**
@@ -56,6 +58,8 @@ class DeveloperTermsAndConditionsController extends LegalEntityTermsAndCondition
      */
     protected function getAcceptTermsAndConditionsEndpoint(string $tncId): UriInterface
     {
-        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$this->developerId}/tncs/{$tncId}/developer-tncs");
+        $developerId = rawurlencode($this->developerId);
+
+        return $this->client->getUriFactory()->createUri("/mint/organizations/{$this->organization}/developers/{$developerId}/tncs/{$tncId}/developer-tncs");
     }
 }

--- a/src/Controller/AbstractEntityController.php
+++ b/src/Controller/AbstractEntityController.php
@@ -58,7 +58,8 @@ abstract class AbstractEntityController extends AbstractController
      */
     protected function getEntityEndpointUri(string $entityId): UriInterface
     {
-        $encoded = urlencode($entityId);
+        $encoded = rawurlencode($entityId);
+
         return $this->getBaseEndpointUri()->withPath("{$this->getBaseEndpointUri()}/{$encoded}");
     }
 

--- a/src/Controller/AbstractEntityController.php
+++ b/src/Controller/AbstractEntityController.php
@@ -58,7 +58,8 @@ abstract class AbstractEntityController extends AbstractController
      */
     protected function getEntityEndpointUri(string $entityId): UriInterface
     {
-        return $this->getBaseEndpointUri()->withPath("{$this->getBaseEndpointUri()}/{$entityId}");
+        $encoded = urlencode($entityId);
+        return $this->getBaseEndpointUri()->withPath("{$this->getBaseEndpointUri()}/{$encoded}");
     }
 
     /**

--- a/tests/Api/Management/Controller/ApiProductControllerTest.php
+++ b/tests/Api/Management/Controller/ApiProductControllerTest.php
@@ -18,9 +18,13 @@
 
 namespace Apigee\Edge\Tests\Api\Management\Controller;
 
+use Apigee\Edge\Api\Management\Entity\ApiProduct;
+use Apigee\Edge\Api\Management\Entity\ApiProductInterface;
 use Apigee\Edge\ClientInterface;
 use Apigee\Edge\Entity\EntityInterface;
+use Apigee\Edge\Structure\AttributesProperty;
 use Apigee\Edge\Tests\Api\Management\Entity\ApiProductTestEntityProviderTrait;
+use Apigee\Edge\Tests\Api\Management\Entity\ParameterUrlEncodingTestTrait;
 use Apigee\Edge\Tests\Test\Controller\DefaultAPIClientAwareTrait;
 use Apigee\Edge\Tests\Test\Controller\EntityControllerTesterInterface;
 use Apigee\Edge\Tests\Test\Controller\EntityCreateOperationControllerTester;
@@ -42,6 +46,7 @@ class ApiProductControllerTest extends EntityControllerTestBase
     use ApiProductControllerAwareTestTrait;
     use ApiProductTestEntityProviderTrait;
     use DefaultAPIClientAwareTrait;
+    use ParameterUrlEncodingTestTrait;
     // The order of these trait matters. Check @depends in test methods.
     use EntityCreateOperationControllerTestTrait;
     use EntityLoadOperationControllerTestTrait;
@@ -111,5 +116,23 @@ class ApiProductControllerTest extends EntityControllerTestBase
     protected static function entityCreateOperationTestController(): EntityCreateOperationTestControllerTesterInterface
     {
         return new EntityCreateOperationControllerTester(static::entityController());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function getEntityToTestUrlEncoding(): EntityInterface
+    {
+        // Use a name that makes use of URL encoding to test that CRUD works with encoding (a space in this case).
+        return new ApiProduct([
+            'name' => static::randomGenerator()->machineName() . ' ' . static::randomGenerator()->machineName(),
+            'displayName' => static::randomGenerator()->displayName(),
+            'approvalType' => ApiProductInterface::APPROVAL_TYPE_AUTO,
+            'attributes' => new AttributesProperty(['foo' => 'bar']),
+            'scopes' => ['scope 1', 'scope 2'],
+            'quota' => static::randomGenerator()->number(),
+            'quotaInterval' => static::randomGenerator()->number(),
+            'quotaTimeUnit' => ApiProductInterface::QUOTA_INTERVAL_MINUTE,
+        ]);
     }
 }

--- a/tests/Api/Management/Controller/DeveloperAppControllerTest.php
+++ b/tests/Api/Management/Controller/DeveloperAppControllerTest.php
@@ -18,11 +18,13 @@
 
 namespace Apigee\Edge\Tests\Api\Management\Controller;
 
+use Apigee\Edge\Api\Management\Entity\DeveloperApp;
 use Apigee\Edge\Api\Management\Entity\DeveloperInterface;
 use Apigee\Edge\ClientInterface;
 use Apigee\Edge\Entity\EntityInterface;
 use Apigee\Edge\Tests\Api\Management\Entity\DeveloperAppTestEntityProviderTrait;
 use Apigee\Edge\Tests\Api\Management\Entity\DeveloperTestEntityProviderTrait;
+use Apigee\Edge\Tests\Api\Management\Entity\ParameterUrlEncodingTestTrait;
 use Apigee\Edge\Tests\Test\Controller\EntityControllerTesterInterface;
 use Apigee\Edge\Tests\Test\Controller\EntityCreateOperationControllerTester;
 use Apigee\Edge\Tests\Test\Controller\EntityCreateOperationTestControllerTesterInterface;
@@ -40,6 +42,7 @@ class DeveloperAppControllerTest extends AppControllerTestBase
     use DeveloperAppTestEntityProviderTrait;
     use DeveloperControllerAwareTestTrait;
     use DeveloperTestEntityProviderTrait;
+    use ParameterUrlEncodingTestTrait;
 
     /** @var \Apigee\Edge\Api\Management\Entity\DeveloperInterface */
     protected static $testDeveloper;
@@ -101,5 +104,21 @@ class DeveloperAppControllerTest extends AppControllerTestBase
     protected function reloadAppOwner()
     {
         return static::developerController()->load(static::$testDeveloper->id());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function getEntityToTestUrlEncoding(): EntityInterface
+    {
+        // Use a name that makes use of URL encoding to test that CRUD works with encoding (a space in this case).
+        $entity = new DeveloperApp([
+            'name' => static::randomGenerator()->machineName() . ' ' . static::randomGenerator()->machineName(),
+            'apiProducts' => [static::$testApiProduct->id()],
+            'callbackUrl' => 'http://example.com',
+        ]);
+        $entity->setDisplayName(static::randomGenerator()->displayName());
+
+        return $entity;
     }
 }

--- a/tests/Api/Management/Controller/DeveloperControllerTest.php
+++ b/tests/Api/Management/Controller/DeveloperControllerTest.php
@@ -22,7 +22,9 @@ use Apigee\Edge\Api\Management\Entity\Developer;
 use Apigee\Edge\Api\Management\Entity\DeveloperInterface;
 use Apigee\Edge\ClientInterface;
 use Apigee\Edge\Entity\EntityInterface;
+use Apigee\Edge\Structure\AttributesProperty;
 use Apigee\Edge\Tests\Api\Management\Entity\DeveloperTestEntityProviderTrait;
+use Apigee\Edge\Tests\Api\Management\Entity\ParameterUrlEncodingTestTrait;
 use Apigee\Edge\Tests\Test\Controller\DefaultAPIClientAwareTrait;
 use Apigee\Edge\Tests\Test\Controller\EntityControllerTesterInterface;
 use Apigee\Edge\Tests\Test\Controller\EntityCreateOperationControllerTester;
@@ -49,6 +51,7 @@ class DeveloperControllerTest extends EntityControllerTestBase
     use DefaultAPIClientAwareTrait;
     use MarkOnlineTestSkippedAwareTrait;
     use MockClientAwareTrait;
+    use ParameterUrlEncodingTestTrait;
     // The order of these trait matters. Check @depends in test methods.
     use EntityCreateOperationControllerTestTrait;
     use EntityLoadOperationControllerTestTrait;
@@ -120,6 +123,21 @@ class DeveloperControllerTest extends EntityControllerTestBase
         // Empty response should trigger an exception.
         $httpClient->addResponse(new Response(200, ['Content-Type' => 'application/json'], json_encode(['developer' => []])));
         $controller->getDeveloperByApp('app1');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected static function getEntityToTestUrlEncoding(): EntityInterface
+    {
+        // Use a developer email that makes use of URL encoding to test that CRUD works with encoding.
+        return new Developer([
+            'email' => 'php+unit+test@example.com',
+            'firstName' => static::randomGenerator()->displayName(),
+            'lastName' => static::randomGenerator()->displayName(),
+            'userName' => static::randomGenerator()->machineName(),
+            'attributes' => new AttributesProperty([static::randomGenerator()->machineName() => static::randomGenerator()->machineName()]),
+        ]);
     }
 
     /**

--- a/tests/Api/Management/Entity/ParameterUrlEncodingTestTrait.php
+++ b/tests/Api/Management/Entity/ParameterUrlEncodingTestTrait.php
@@ -22,26 +22,24 @@ use Apigee\Edge\Api\Management\Entity\DeveloperInterface;
 use Apigee\Edge\Entity\EntityInterface;
 use Apigee\Edge\Tests\Test\Controller\EntityCreateOperationTestControllerTesterInterface;
 use Apigee\Edge\Tests\Test\Controller\EntityLoadOperationControllerTesterInterface;
+use Apigee\Edge\Tests\Test\Utility\MarkOnlineTestSkippedAwareTrait;
 
 trait ParameterUrlEncodingTestTrait
 {
+    use MarkOnlineTestSkippedAwareTrait;
+
     /**
      * Use an entity with an ID that makes use of URL encoding to test that CRUD works with encoding.
      */
     public function testUrlEncoding(): void
     {
+        static::markOnlineTestSkipped(__FUNCTION__);
+
         $entity = static::getEntityToTestUrlEncoding();
         $original = clone $entity;
         static::controllerForEntityCreate()->create($entity);
         $this->validateCreatedEntity($entity, $original);
 
-        if ($entity instanceof DeveloperInterface) {
-            var_dump($entity->getEmail());
-            var_dump($original->getEmail());
-        } else {
-            var_dump($entity->id());
-            var_dump($original->id());
-        }
         // Test the entity can be retrieved.
         $id = ($entity instanceof DeveloperInterface) ? $entity->getEmail() : $entity->id();
         $loaded = static::controllerForEntityLoad()->load($id);

--- a/tests/Api/Management/Entity/ParameterUrlEncodingTestTrait.php
+++ b/tests/Api/Management/Entity/ParameterUrlEncodingTestTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apigee\Edge\Tests\Api\Management\Entity;
+
+use Apigee\Edge\Api\Management\Entity\DeveloperInterface;
+use Apigee\Edge\Entity\EntityInterface;
+use Apigee\Edge\Tests\Test\Controller\EntityCreateOperationTestControllerTesterInterface;
+use Apigee\Edge\Tests\Test\Controller\EntityLoadOperationControllerTesterInterface;
+
+trait ParameterUrlEncodingTestTrait
+{
+    /**
+     * Use an entity with an ID that makes use of URL encoding to test that CRUD works with encoding.
+     */
+    public function testUrlEncoding(): void
+    {
+        $entity = static::getEntityToTestUrlEncoding();
+        $original = clone $entity;
+        static::controllerForEntityCreate()->create($entity);
+        $this->validateCreatedEntity($entity, $original);
+
+        if ($entity instanceof DeveloperInterface) {
+            var_dump($entity->getEmail());
+            var_dump($original->getEmail());
+        } else {
+            var_dump($entity->id());
+            var_dump($original->id());
+        }
+        // Test the entity can be retrieved.
+        $id = ($entity instanceof DeveloperInterface) ? $entity->getEmail() : $entity->id();
+        $loaded = static::controllerForEntityLoad()->load($id);
+        $this->validateLoadedEntity($entity, $loaded);
+    }
+
+    /**
+     * Return an entity with an ID that makes use of URL encoding.
+     *
+     * @return EntityInterface
+     */
+    abstract protected static function getEntityToTestUrlEncoding(): EntityInterface;
+
+    abstract protected static function controllerForEntityCreate(): EntityCreateOperationTestControllerTesterInterface;
+
+    abstract protected static function controllerForEntityLoad(): EntityLoadOperationControllerTesterInterface;
+}

--- a/tests/Api/Monetization/Controller/DeveloperPrepaidBalanceControllerTest.php
+++ b/tests/Api/Monetization/Controller/DeveloperPrepaidBalanceControllerTest.php
@@ -49,7 +49,7 @@ class DeveloperPrepaidBalanceControllerTest extends PrepaidBalanceControllerTest
      */
     protected static function validateRecurringPath(string $actual): void
     {
-        $developerId = self::$developerId;
+        $developerId = rawurlencode(self::$developerId);
         Assert::assertEquals("/v1/mint/organizations/phpunit/developers/{$developerId}/developer-balances/recurring-setup", $actual);
     }
 }

--- a/tests/Api/Monetization/Controller/DeveloperReportDefinitionControllerTest.php
+++ b/tests/Api/Monetization/Controller/DeveloperReportDefinitionControllerTest.php
@@ -48,6 +48,6 @@ class DeveloperReportDefinitionControllerTest extends ReportDefinitionController
      */
     protected function expectedFilteredReportDefinitionUrl(): string
     {
-        return sprintf('/v1/mint/organizations/%s/developers/%s/report-definitions', static::defaultTestOrganization(static::mockApiClient()), static::TEST_DEVELOPER_ID);
+        return sprintf('/v1/mint/organizations/%s/developers/%s/report-definitions', static::defaultTestOrganization(static::mockApiClient()), rawurlencode(static::TEST_DEVELOPER_ID));
     }
 }

--- a/tests/Api/Monetization/Controller/DeveloperTermsAndConditionsControllerTest.php
+++ b/tests/Api/Monetization/Controller/DeveloperTermsAndConditionsControllerTest.php
@@ -49,6 +49,6 @@ class DeveloperTermsAndConditionsControllerTest extends LegalEntityTermsAndCondi
      */
     protected function expectedAcceptDeclineEndpoint(): string
     {
-        return sprintf('/v1/mint/organizations/phpunit/developers/%s/tncs/phpunit/developer-tncs', static::$testDeveloperId);
+        return sprintf('/v1/mint/organizations/phpunit/developers/%s/tncs/phpunit/developer-tncs', rawurlencode(static::$testDeveloperId));
     }
 }


### PR DESCRIPTION
Fixes #86 by URL encoding the entity IDs before adding them to the URI.