### PR TITLE
Verify empty response on normalizeExpandFalseForHybrid().

### DIFF
--- a/src/Utility/ResponseToArrayHelper.php
+++ b/src/Utility/ResponseToArrayHelper.php
@@ -89,7 +89,7 @@ trait ResponseToArrayHelper
     {
         // If empty, no further processing is needed.
         if (empty($responseArray)) {
-            return  $responseArray;
+            return $responseArray;
         }
 
         // Ignore entity type key from response, ex.: apiProduct.

--- a/src/Utility/ResponseToArrayHelper.php
+++ b/src/Utility/ResponseToArrayHelper.php
@@ -87,6 +87,11 @@ trait ResponseToArrayHelper
      */
     protected function normalizeExpandFalseForHybrid(array $responseArray): array
     {
+        // If empty, no further processing is needed.
+        if (empty($responseArray)) {
+            return  $responseArray;
+        }
+
         // Ignore entity type key from response, ex.: apiProduct.
         $responseArray = reset($responseArray);
 

--- a/tests/Utility/ResponseToArrayHelperTest.php
+++ b/tests/Utility/ResponseToArrayHelperTest.php
@@ -68,7 +68,8 @@ class ResponseToArrayHelperTest extends TestCase
      * @return array
      *   The array of values to run tests on.
      */
-    public function expandCompatibilityDataProvider() {
+    public function expandCompatibilityDataProvider()
+    {
         return [
             // Test a response.
             ['["helloworld","weather"]', '{"proxies":[{"name":"helloworld"},{"name":"weather"}]}'],
@@ -76,5 +77,4 @@ class ResponseToArrayHelperTest extends TestCase
             ['[]', '{}'],
         ];
     }
-
 }

--- a/tests/Utility/ResponseToArrayHelperTest.php
+++ b/tests/Utility/ResponseToArrayHelperTest.php
@@ -70,9 +70,23 @@ class ResponseToArrayHelperTest extends TestCase
      */
     public function expandCompatibilityDataProvider()
     {
+        $edgeStyleNonEmpty = [
+            'helloworld',
+            'weather',
+        ];
+        $hybridStyleNonEmpty = (object) [
+            'proxies' => [
+                (object) [
+                    'name' => 'helloworld',
+                ],
+                (object) [
+                    'name' => 'weather',
+                ],
+            ],
+        ];
         return [
             // Test a response.
-            ['["helloworld","weather"]', '{"proxies":[{"name":"helloworld"},{"name":"weather"}]}'],
+            [json_encode($edgeStyleNonEmpty), json_encode($hybridStyleNonEmpty)],
             // Test an empty response.
             ['[]', '{}'],
         ];

--- a/tests/Utility/ResponseToArrayHelperTest.php
+++ b/tests/Utility/ResponseToArrayHelperTest.php
@@ -42,21 +42,39 @@ class ResponseToArrayHelperTest extends TestCase
 
     /**
      * Tests the expand parameter compatibility.
+     *
+     * @dataProvider expandCompatibilityDataProvider
      */
-    public function testExpandCompatibility(): void
+    public function testExpandCompatibility($edgeResponse, $hybridResponse): void
     {
         /** @var \Psr\Http\Message\ResponseInterface $response1 */
         $response1 = $this->getMockBuilder(ResponseInterface::class)->getMock();
         $response1->method('getHeaderLine')->willReturn('application/json');
-        $response1->method('getBody')->willReturn('["helloworld","weather"]');
+        $response1->method('getBody')->willReturn($edgeResponse);
         $decodedEdgeStyle = $this->responseToArrayHelper->convertResponseToArray($response1, false);
 
         /** @var \Psr\Http\Message\ResponseInterface $response2 */
         $response2 = $this->getMockBuilder(ResponseInterface::class)->getMock();
         $response2->method('getHeaderLine')->willReturn('application/json');
-        $response2->method('getBody')->willReturn('{"proxies":[{"name":"helloworld"},{"name":"weather"}]}');
+        $response2->method('getBody')->willReturn($hybridResponse);
         $decodedWithCompatibility = $this->responseToArrayHelper->convertResponseToArray($response2, true);
 
         $this->assertEquals($decodedEdgeStyle, $decodedWithCompatibility);
     }
+
+    /**
+     * DataProvider for testExpandCompatibility.
+     *
+     * @return array
+     *   The array of values to run tests on.
+     */
+    public function expandCompatibilityDataProvider() {
+        return [
+            // Test a response.
+            ['["helloworld","weather"]', '{"proxies":[{"name":"helloworld"},{"name":"weather"}]}'],
+            // Test an empty response.
+            ['[]', '{}'],
+        ];
+    }
+
 }


### PR DESCRIPTION
Fixing an issue related to #85 when the response is empty. Also added a test scenario for this.