### PR TITLE
[#296-apigee edge drupal]

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -208,7 +208,7 @@ class Client implements ClientInterface
     public function post($uri, $body = null, array $headers = []): ResponseInterface
     {
         if (!isset($headers['Content-Type'])) {
-            $headers['Content-Type'] = 'application/json; charset=utf-8';
+            $headers['Content-Type'] = 'application/json';
         }
 
         return $this->send('POST', $uri, $headers, $body);
@@ -220,7 +220,7 @@ class Client implements ClientInterface
     public function put($uri, $body = null, array $headers = []): ResponseInterface
     {
         if (!isset($headers['Content-Type'])) {
-            $headers['Content-Type'] = 'application/json; charset=utf-8';
+            $headers['Content-Type'] = 'application/json';
         }
 
         return $this->send('PUT', $uri, $headers, $body);

--- a/src/Exception/ApiResponseException.php
+++ b/src/Exception/ApiResponseException.php
@@ -118,7 +118,11 @@ class ApiResponseException extends ApiRequestException
                 } else {
                     if (array_key_exists('code', $array)) {
                         $error['code'] = $array['code'];
+                    } elseif (isset($array['error']['details'][0]['violations'][0]['type'])) {
+                        // Hybrid returns the Edge error code here.
+                        $error['code'] = $array['error']['details'][0]['violations'][0]['type'];
                     } elseif (isset($array['error']['code'])) {
+                        // Fallback for Hybrid if the above is not set.
                         $error['code'] = $array['error']['code'];
                     }
                     if (array_key_exists('message', $array)) {


### PR DESCRIPTION
Helps fix https://github.com/apigee/apigee-edge-drupal/issues/296. Two issues are resolved:
- Retrieve the "Edge error code" correctly (ie, the error code of type `developer.service.AppDoesNotExist`), as Hybrid returns it under a substructure, which we try to parse.
- Hybrid is strict about headers, and it does not accept `$headers['Content-Type'] = 'application/json; charset=utf-8';` - it returns an error 400 _(Request contains an invalid argument)_ for POST/PUT. It will only use `$headers['Content-Type'] = 'application/json`. Current Edge API also supports this change.