### PR TITLE
Use toDate instead of endDate for revenue report criteria

### DIFF
--- a/src/Api/Monetization/Structure/Reports/Criteria/RevenueReportCriteria.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/RevenueReportCriteria.php
@@ -31,7 +31,7 @@ final class RevenueReportCriteria extends AbstractCriteria
     /**
      * @var \DateTimeImmutable|null
      */
-    private $endDate;
+    private $toDate;
 
     /**
      * Array of developer attributes to be displayed in the report.
@@ -59,12 +59,12 @@ final class RevenueReportCriteria extends AbstractCriteria
      * RevenueReportCriteria constructor.
      *
      * @param \DateTimeImmutable $fromDate
-     * @param \DateTimeImmutable|null $endDate
+     * @param \DateTimeImmutable|null $toDate
      */
-    public function __construct(\DateTimeImmutable $fromDate, ?\DateTimeImmutable $endDate = null)
+    public function __construct(\DateTimeImmutable $fromDate, ?\DateTimeImmutable $toDate = null)
     {
         $this->fromDate = $fromDate;
-        $this->endDate = $endDate;
+        $this->toDate = $toDate;
     }
 
     /**
@@ -78,9 +78,9 @@ final class RevenueReportCriteria extends AbstractCriteria
     /**
      * @return \DateTimeImmutable|null
      */
-    public function getEndDate(): ?\DateTimeImmutable
+    public function getToDate(): ?\DateTimeImmutable
     {
-        return $this->endDate;
+        return $this->toDate;
     }
 
     /**


### PR DESCRIPTION
See https://apidocs.apigee.com/monetize/apis/post/organizations/%7Borg_name%7D/%7Breport_type%7D

Existing tests are using `toDate` as well: https://github.com/apigee/apigee-client-php/blob/02dd82ec6bcb6d4f4ffca12f072c4ac6b992d998/tests/Api/Monetization/Denormalizer/ReportCriteriaDenormalizerTest.php#L110