### PR TITLE
Handle possible null value caused by missing value in response payload

### DIFF
--- a/src/Api/Management/Controller/AttributesAwareEntityControllerTrait.php
+++ b/src/Api/Management/Controller/AttributesAwareEntityControllerTrait.php
@@ -58,7 +58,7 @@ trait AttributesAwareEntityControllerTrait
             $this->getEntityAttributeUri($entityId, $name)
         ));
 
-        return $responseArray['value'];
+        return $responseArray['value'] ?? '';
     }
 
     /**


### PR DESCRIPTION
If an attribute's value is an empty string then this API endpoint does not return the "value" in the API response only the "name".

So instead of 

```json
{
    "name": "DisplayName",
    "value": "someapp"
}
```
what is returned is

```json
{
    "name": "DisplayName",
}

```
when

```json
{
    "name": "DisplayName",
    "value": ""
}
```
A related API is: https://apidocs.apigee.com/docs/api-products/1/routes/organizations/%7Borg_name%7D/apiproducts/%7Bapiproduct_name%7D/attributes/%7Battribute_name%7D/get

Needs test coverage.