### PR TITLE
ApiResponseException class throwing error on returning string response #138

### DIFF
--- a/src/Exception/ApiResponseException.php
+++ b/src/Exception/ApiResponseException.php
@@ -61,7 +61,7 @@ class ApiResponseException extends ApiRequestException
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function __toString()
     {
@@ -111,6 +111,7 @@ class ApiResponseException extends ApiRequestException
         $contentTypeHeader = $response->getHeaderLine('Content-Type');
         if ($contentTypeHeader && false !== strpos($contentTypeHeader, 'application/json')) {
             $array = json_decode((string) $response->getBody(), true);
+            $array = is_array($array) ? $array : (array) $array;
             if (JSON_ERROR_NONE === json_last_error()) {
                 if (array_key_exists('fault', $array)) {
                     $error['message'] = $array['fault']['faultstring'] ?? null;

--- a/src/Exception/ApiResponseException.php
+++ b/src/Exception/ApiResponseException.php
@@ -112,6 +112,7 @@ class ApiResponseException extends ApiRequestException
         if ($contentTypeHeader && false !== strpos($contentTypeHeader, 'application/json')) {
             $array = json_decode((string) $response->getBody(), true);
             $array = is_array($array) ? $array : (array) $array;
+
             if (JSON_ERROR_NONE === json_last_error()) {
                 if (array_key_exists('fault', $array)) {
                     $error['message'] = $array['fault']['faultstring'] ?? null;


### PR DESCRIPTION
Closes #138 

- Converted string  to array when  **service-accounts/default/token** API returns `No service account scopes specified.` as string.

- Resolved php-csc-fix error 