### PR TITLE
Error while purchasing plan - PHP 7.3 (Apigee X - 5G)

### DIFF
--- a/src/Api/ApigeeX/Entity/RatePlan.php
+++ b/src/Api/ApigeeX/Entity/RatePlan.php
@@ -63,9 +63,6 @@ abstract class RatePlan extends Entity implements RatePlanInterface
      */
     protected $package;
 
-    /** @var bool */
-    protected $published = false;
-
     /** @var \Apigee\Edge\Api\ApigeeX\Structure\RatePlanXFee[] */
     protected $ratePlanXFee = [];
 


### PR DESCRIPTION
Closes #150 

Error while purchasing plan on Apigee X when the PHP version is 7.3, 

Removed unused property "**published**" which was causing error on "PropertyAccessor class".
