### PR TITLE
Fix user profile update not working on Apigee X (PUT /developers)

### DIFF
--- a/src/Api/Management/Controller/DeveloperController.php
+++ b/src/Api/Management/Controller/DeveloperController.php
@@ -98,7 +98,7 @@ class DeveloperController extends PaginatedEntityController implements Developer
     /**
      * {@inheritdoc}
      *
-     * We are enforcing email addresses over developer ids (UUIDs) when we are updating user profile.
+     * We are enforcing email addresses over developer-ids (UUIDs) when we are updating user profile.
      *
      * @psalm-suppress UndefinedMethod
      *

--- a/src/Api/Management/Controller/DeveloperController.php
+++ b/src/Api/Management/Controller/DeveloperController.php
@@ -30,6 +30,7 @@ use Apigee\Edge\Controller\PaginatedEntityIdListingControllerTrait;
 use Apigee\Edge\Controller\PaginatedEntityListingControllerTrait;
 use Apigee\Edge\Controller\PaginationHelperTrait;
 use Apigee\Edge\Controller\StatusAwareEntityControllerTrait;
+use Apigee\Edge\Entity\EntityInterface;
 use Apigee\Edge\Serializer\EntitySerializerInterface;
 use Apigee\Edge\Structure\PagerInterface;
 use Psr\Http\Message\UriInterface;
@@ -64,7 +65,7 @@ class DeveloperController extends PaginatedEntityController implements Developer
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getDeveloperByApp(string $appName): DeveloperInterface
     {
@@ -83,7 +84,7 @@ class DeveloperController extends PaginatedEntityController implements Developer
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getEntities(
         PagerInterface $pager = null,
@@ -95,7 +96,24 @@ class DeveloperController extends PaginatedEntityController implements Developer
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
+     *
+     * We are enforcing email addresses over developer ids (UUIDs) when we are updating user profile.
+     *
+     *  @see https://github.com/apigee/apigee-edge-drupal/issues/594
+     */
+    public function update(EntityInterface $entity): void
+    {
+        $uri = $this->getEntityEndpointUri($entity->originalEmail());
+        $response = $this->getClient()->put(
+            $uri,
+            $this->getEntitySerializer()->serialize($entity, 'json')
+        );
+        $this->getEntitySerializer()->setPropertiesFromResponse($response, $entity);
+    }
+
+    /**
+     * {@inheritdoc}
      */
     protected function getBaseEndpointUri(): UriInterface
     {
@@ -104,7 +122,7 @@ class DeveloperController extends PaginatedEntityController implements Developer
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function getEntityClass(): string
     {

--- a/src/Api/Management/Controller/DeveloperController.php
+++ b/src/Api/Management/Controller/DeveloperController.php
@@ -98,7 +98,7 @@ class DeveloperController extends PaginatedEntityController implements Developer
     /**
      * {@inheritdoc}
      *
-     * We are enforcing email addresses over developer ids (UUIDs) when we are updating user profile.
+     * We are enforcing email addresses over developer-ids (UUIDs) when we are updating user profile.
      *
      * @psalm-suppress PossiblyNullArgument $entity->originalEmail() is not null here.
      *

--- a/src/Api/Management/Controller/DeveloperController.php
+++ b/src/Api/Management/Controller/DeveloperController.php
@@ -100,6 +100,8 @@ class DeveloperController extends PaginatedEntityController implements Developer
      *
      * We are enforcing email addresses over developer ids (UUIDs) when we are updating user profile.
      *
+     * @psalm-suppress UndefinedMethod
+     *
      *  @see https://github.com/apigee/apigee-client-php/issues/153
      */
     public function update(EntityInterface $entity): void

--- a/src/Api/Management/Controller/DeveloperController.php
+++ b/src/Api/Management/Controller/DeveloperController.php
@@ -98,20 +98,22 @@ class DeveloperController extends PaginatedEntityController implements Developer
     /**
      * {@inheritdoc}
      *
-     * We are enforcing email addresses over developer-ids (UUIDs) when we are updating user profile.
+     * We are enforcing email addresses over developer ids (UUIDs) when we are updating user profile.
      *
-     * @psalm-suppress UndefinedMethod
+     * @psalm-suppress PossiblyNullArgument $entity->originalEmail() is not null here.
      *
      *  @see https://github.com/apigee/apigee-client-php/issues/153
      */
     public function update(EntityInterface $entity): void
     {
-        $uri = $this->getEntityEndpointUri($entity->originalEmail());
+        /** @var \Apigee\Edge\Api\Management\Entity\Developer $entity */
+        $developer_entity = $entity;
+        $uri = $this->getEntityEndpointUri($developer_entity->originalEmail());
         $response = $this->getClient()->put(
             $uri,
-            $this->getEntitySerializer()->serialize($entity, 'json')
+            $this->getEntitySerializer()->serialize($developer_entity, 'json')
         );
-        $this->getEntitySerializer()->setPropertiesFromResponse($response, $entity);
+        $this->getEntitySerializer()->setPropertiesFromResponse($response, $developer_entity);
     }
 
     /**

--- a/src/Api/Management/Controller/DeveloperController.php
+++ b/src/Api/Management/Controller/DeveloperController.php
@@ -102,7 +102,7 @@ class DeveloperController extends PaginatedEntityController implements Developer
      *
      * @psalm-suppress PossiblyNullArgument $entity->originalEmail() is not null here.
      *
-     *  @see https://github.com/apigee/apigee-client-php/issues/153
+     * @see https://github.com/apigee/apigee-client-php/issues/153
      */
     public function update(EntityInterface $entity): void
     {

--- a/src/Api/Management/Controller/DeveloperController.php
+++ b/src/Api/Management/Controller/DeveloperController.php
@@ -100,7 +100,7 @@ class DeveloperController extends PaginatedEntityController implements Developer
      *
      * We are enforcing email addresses over developer ids (UUIDs) when we are updating user profile.
      *
-     *  @see https://github.com/apigee/apigee-edge-drupal/issues/594
+     *  @see https://github.com/apigee/apigee-client-php/issues/153
      */
     public function update(EntityInterface $entity): void
     {

--- a/src/Api/Management/Entity/Developer.php
+++ b/src/Api/Management/Entity/Developer.php
@@ -45,6 +45,13 @@ class Developer extends AppOwner implements DeveloperInterface
     protected $companies = [];
 
     /**
+    * The original email address of the developer.
+    *
+    * @var string|null
+    */
+    protected $originalEmail;
+
+    /**
      * Developer constructor.
      *
      * @param array $values
@@ -56,7 +63,7 @@ class Developer extends AppOwner implements DeveloperInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static function idProperty(): string
     {
@@ -68,7 +75,7 @@ class Developer extends AppOwner implements DeveloperInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getCompanies(): array
     {
@@ -91,7 +98,7 @@ class Developer extends AppOwner implements DeveloperInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function hasCompany(string $companyName): bool
     {
@@ -99,7 +106,7 @@ class Developer extends AppOwner implements DeveloperInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getUserName(): ?string
     {
@@ -107,7 +114,7 @@ class Developer extends AppOwner implements DeveloperInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setUserName(string $userName): void
     {
@@ -115,7 +122,7 @@ class Developer extends AppOwner implements DeveloperInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getFirstName(): ?string
     {
@@ -123,7 +130,7 @@ class Developer extends AppOwner implements DeveloperInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setFirstName(string $firstName): void
     {
@@ -131,7 +138,7 @@ class Developer extends AppOwner implements DeveloperInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getLastName(): ?string
     {
@@ -139,10 +146,31 @@ class Developer extends AppOwner implements DeveloperInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLastName(string $lastName): void
     {
         $this->lastName = $lastName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEmail(string $email): void
+    {
+        $this->email = $email;
+        if (null === $this->originalEmail) {
+            $this->originalEmail = $email;
+        }
+    }
+
+    /**
+     * The original email address of the developer used when updating user email address.
+     *
+     * @see Apigee\Edge\Api\Management\Controller\DeveloperController
+     */
+    public function originalEmail(): ?string
+    {
+        return $this->originalEmail;
     }
 }

--- a/src/Api/Management/Entity/Developer.php
+++ b/src/Api/Management/Entity/Developer.php
@@ -168,6 +168,8 @@ class Developer extends AppOwner implements DeveloperInterface
      * The original email address of the developer used when updating user email address.
      *
      * @see Apigee\Edge\Api\Management\Controller\DeveloperController
+     *
+     * @internal 'get'is not prefixed to this method to prevent added to the request payload.
      */
     public function originalEmail(): ?string
     {

--- a/src/Api/Management/Entity/Developer.php
+++ b/src/Api/Management/Entity/Developer.php
@@ -49,7 +49,7 @@ class Developer extends AppOwner implements DeveloperInterface
     *
     * @var string|null
     */
-    protected $originalEmail;
+    private $originalEmail;
 
     /**
      * Developer constructor.

--- a/src/Entity/Property/EmailPropertyAwareTrait.php
+++ b/src/Entity/Property/EmailPropertyAwareTrait.php
@@ -24,13 +24,6 @@ trait EmailPropertyAwareTrait
     protected $email;
 
     /**
-    * The original email address of the developer.
-    *
-    * @var string|null
-    */
-    protected $originalEmail;
-
-    /**
      * {@inheritdoc}
      */
     public function getEmail(): ?string
@@ -44,16 +37,5 @@ trait EmailPropertyAwareTrait
     public function setEmail(string $email): void
     {
         $this->email = $email;
-        if (null === $this->originalEmail) {
-            $this->originalEmail = $email;
-        }
-    }
-
-    /**
-     * The original email address of the developer used when updating user email address.
-     */
-    public function originalEmail(): ?string
-    {
-        return $this->originalEmail;
     }
 }

--- a/src/Entity/Property/EmailPropertyAwareTrait.php
+++ b/src/Entity/Property/EmailPropertyAwareTrait.php
@@ -24,7 +24,14 @@ trait EmailPropertyAwareTrait
     protected $email;
 
     /**
-     * @inheritdoc
+    * The original email address of the developer.
+    *
+    * @var string|null
+    */
+    protected $originalEmail;
+
+    /**
+     * {@inheritdoc}
      */
     public function getEmail(): ?string
     {
@@ -32,10 +39,21 @@ trait EmailPropertyAwareTrait
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setEmail(string $email): void
     {
         $this->email = $email;
+        if (null === $this->originalEmail) {
+            $this->originalEmail = $email;
+        }
+    }
+
+    /**
+     * The original email address of the developer used when updating user email address.
+     */
+    public function originalEmail(): ?string
+    {
+        return $this->originalEmail;
     }
 }

--- a/tests/offline-test-data/v1/organizations/phpunit/developers/phpunit@example.com/PUT.json
+++ b/tests/offline-test-data/v1/organizations/phpunit/developers/phpunit@example.com/PUT.json
@@ -1,0 +1,25 @@
+{
+    "apps": [],
+    "companies": [],
+    "email": "phpunit-edited@example.com",
+    "developerId": "f43ffa3c-e147-47de-8cd6-f5b34429a531",
+    "firstName": "Php",
+    "lastName": "Unit",
+    "userName": "phpunit",
+    "organizationName": "test",
+    "status": "active",
+    "attributes": [
+        {
+            "name": "foo",
+            "value": "foo"
+        },
+        {
+            "name": "bar",
+            "value": "baz"
+        }
+    ],
+    "createdAt": 648345600000,
+    "createdBy": "phpunit@example.com",
+    "lastModifiedAt": 648345600000,
+    "lastModifiedBy": "phpunit@example.com"
+}


### PR DESCRIPTION
Closes  #153 

Fixed issue by providing the developer `email-ID` instead of the developer `UUID` before clients `EntityUpdateOperationControllerTrait` update function is called.  (`PUT /developers` call)
This works for both 4G/ 5G.

Note: Also for Apigee X and hybrid runtime versions 1.5.0 and 1.5.1, a call to change the developer's email address will not work. 
