### PR TITLE
Ignore global averages in optimized metrics calculation

### DIFF
--- a/src/Api/Management/Controller/StatsController.php
+++ b/src/Api/Management/Controller/StatsController.php
@@ -302,7 +302,18 @@ class StatsController extends AbstractController implements StatsControllerInter
     private function fillGapsInMetricsData(bool $tsAscending, array $allTimeUnits, array $originalTimeUnits, array &$metricsData): void
     {
         $zeroArray = array_fill_keys($allTimeUnits, 0);
+        $needs_reindex = false;
         foreach ($metricsData as $key => $metric) {
+            // Ignore and remove every global average metric from results.
+            // As these are global averages, it does not make sense filling
+            // gaps on those. If this information is needed then the
+            // non-optimized method should be used.
+            // @see https://www.googlecloudcommunity.com/gc/Apigee/Analytics-Server-Issue-avg-total-response-time-is-fetching/td-p/58868
+            if (0 === strpos($metric['name'], 'global-')) {
+                unset($metricsData[$key]);
+                $needs_reindex = true;
+                continue;
+            }
             $metricsData[$key]['values'] = array_combine($originalTimeUnits, $metric['values']);
             $metricsData[$key]['values'] += $zeroArray;
             if ($tsAscending) {
@@ -312,6 +323,10 @@ class StatsController extends AbstractController implements StatsControllerInter
             }
             // Keep original numerical indexes.
             $metricsData[$key]['values'] = array_values($metricsData[$key]['values']);
+        }
+        // Just in case, as a "BC layer", re-index the array.
+        if ($needs_reindex) {
+            $metricsData = array_values($metricsData);
         }
     }
 

--- a/tests/Api/Management/Controller/StatsControllerTest.php
+++ b/tests/Api/Management/Controller/StatsControllerTest.php
@@ -171,7 +171,7 @@ class StatsControllerTest extends ControllerTestBase
 
     protected function emptyResponseArray(): array
     {
-        return ['Response' => ['TimeUnit' => [], 'stats' => ['data' => [0 => ['values' => []]]]]];
+        return ['Response' => ['TimeUnit' => [], 'stats' => ['data' => [0 => ['name' => 'foo', 'env' => 'bar', 'values' => []]]]]];
     }
 
     /**


### PR DESCRIPTION
## Problem/Motivation

It seems when Apigee can, it calculates global averages for metrics like `avg(total_response_time)`.  See: https://www.googlecloudcommunity.com/gc/Apigee/Analytics-Server-Issue-avg-total-response-time-is-fetching/td-p/58868

The only problem with this that optimizing these global averages  (making sure that there is a result for every time unit in these metrics) does not make any sense.
When they are returned by the API backend they break current implementation with:

```
Error: Unsupported operand types in Apigee\Edge\Api\Management\Controller\StatsController->fillGapsInMetricsData() (line 307 of /mnt/files/local_mount/build/vendor/apigee/apigee-client-php/src/Api/Management/Controller/StatsController.php) 

Warning: array_combine(): Both parameters should have an equal number of elements in Apigee\Edge\Api\Management\Controller\StatsController->fillGapsInMetricsData() (line 306 of /mnt/files/local_mount/build/vendor/apigee/apigee-client-php/src/Api/Management/Controller/StatsController.php) 
```

caused by 

```json
                    "metric": [
                        {
                            "env": "prod",
                            "name": "avg(total_response_time)",
                            "values": [
                                177.16666666666666,
                                183.55555555555554,
                                176.9,
                                153.63636363636363,
                                154,
                                194.71428571428572,
                                165.625,
                                185.0909090909091,
                                166.41666666666666,
                                208.375,
                                179.4
                            ]
                        },
                        {
                            "env": "prod",
                            "name": "global-avg-total_response_time",
                            "values": [
                                177
                            ]
                        }
                    ]
```

## Needs investigation
Is there a way to convince the Stats API not to generate/return this value? See: https://www.googlecloudcommunity.com/gc/Apigee/Analytics-Server-Issue-avg-total-response-time-is-fetching/td-p/58868