### PR TITLE
Updated user-agent string with additional information

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -172,9 +172,15 @@ class Client implements ClientInterface
     public function getUserAgent(): string
     {
         if (null !== $this->userAgentPrefix) {
+            $userAgent = explode('~', $this->userAgentPrefix);
+            if (count($userAgent) > 1) {
+                if ("" === $userAgent[1]) {
+                    return sprintf("{$userAgent[0]} ({$this->getClientVersion()}; {$userAgent[2]}; {$this->getPHPVersion()})");
+                }
+                return sprintf("{$userAgent[1]} ({$userAgent[0]}; {$this->getClientVersion()}; {$userAgent[2]}; {$this->getPHPVersion()})");
+            }
             return sprintf("{$this->userAgentPrefix} ({$this->getClientVersion()})");
         }
-
         return $this->getClientVersion();
     }
 
@@ -183,7 +189,15 @@ class Client implements ClientInterface
      */
     public function getClientVersion(): string
     {
-        return sprintf('Apigee Edge PHP Client %s', self::VERSION);
+        return sprintf('Apigee Edge PHP Client/%s', self::VERSION);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPHPVersion(): string
+    {
+        return sprintf('PHP/%s', phpversion());
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -171,11 +171,12 @@ class Client implements ClientInterface
      */
     public function getUserAgent(): string
     {
+        $user_agent = $this->getClientVersion() . '; PHP/' . PHP_VERSION;
         if (null !== $this->userAgentPrefix) {
-            return $this->userAgentPrefix . ' (' . $this->getClientVersion() . '; PHP/' . PHP_VERSION . ')';
+            return $this->userAgentPrefix . ' (' . $user_agent . ')';
         }
 
-        return $this->getClientVersion() . '; PHP/' . PHP_VERSION;
+        return $user_agent;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -172,20 +172,10 @@ class Client implements ClientInterface
     public function getUserAgent(): string
     {
         if (null !== $this->userAgentPrefix) {
-            // Checks if userAgent has multiple values in string.
-            $userAgent = explode('~', $this->userAgentPrefix);
-            if (count($userAgent) > 1) {
-                if ('' === $userAgent[1]) {
-                    return "{$userAgent[0]} ({$this->getClientVersion()}; {$userAgent[2]}; PHP/" . phpversion() . ")";
-                }
-
-                return "{$userAgent[1]} ({$userAgent[0]}; {$this->getClientVersion()}; {$userAgent[2]}; PHP/" . phpversion() . ")";
-            }
-
-            return "{$this->userAgentPrefix} ({$this->getClientVersion()})";
+            return $this->userAgentPrefix . ' (' . $this->getClientVersion() . '; PHP/' . PHP_VERSION . ')';
         }
 
-        return $this->getClientVersion();
+        return $this->getClientVersion() . '; PHP/' . PHP_VERSION;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -174,13 +174,16 @@ class Client implements ClientInterface
         if (null !== $this->userAgentPrefix) {
             $userAgent = explode('~', $this->userAgentPrefix);
             if (count($userAgent) > 1) {
-                if ("" === $userAgent[1]) {
+                if ('' === $userAgent[1]) {
                     return sprintf("{$userAgent[0]} ({$this->getClientVersion()}; {$userAgent[2]}; {$this->getPHPVersion()})");
                 }
+
                 return sprintf("{$userAgent[1]} ({$userAgent[0]}; {$this->getClientVersion()}; {$userAgent[2]}; {$this->getPHPVersion()})");
             }
+
             return sprintf("{$this->userAgentPrefix} ({$this->getClientVersion()})");
         }
+
         return $this->getClientVersion();
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -172,16 +172,17 @@ class Client implements ClientInterface
     public function getUserAgent(): string
     {
         if (null !== $this->userAgentPrefix) {
+            // Checks if userAgent has multiple values in string.
             $userAgent = explode('~', $this->userAgentPrefix);
             if (count($userAgent) > 1) {
                 if ('' === $userAgent[1]) {
-                    return sprintf("{$userAgent[0]} ({$this->getClientVersion()}; {$userAgent[2]}; {$this->getPHPVersion()})");
+                    return "{$userAgent[0]} ({$this->getClientVersion()}; {$userAgent[2]}; PHP/" . phpversion() . ")";
                 }
 
-                return sprintf("{$userAgent[1]} ({$userAgent[0]}; {$this->getClientVersion()}; {$userAgent[2]}; {$this->getPHPVersion()})");
+                return "{$userAgent[1]} ({$userAgent[0]}; {$this->getClientVersion()}; {$userAgent[2]}; PHP/" . phpversion() . ")";
             }
 
-            return sprintf("{$this->userAgentPrefix} ({$this->getClientVersion()})");
+            return "{$this->userAgentPrefix} ({$this->getClientVersion()})";
         }
 
         return $this->getClientVersion();
@@ -193,14 +194,6 @@ class Client implements ClientInterface
     public function getClientVersion(): string
     {
         return sprintf('Apigee Edge PHP Client/%s', self::VERSION);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getPHPVersion(): string
-    {
-        return sprintf('PHP/%s', phpversion());
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -90,7 +90,7 @@ class ClientTest extends TestCase
         $client = new Client(new NullAuthentication(), null, [Client::CONFIG_USER_AGENT_PREFIX => $userAgentPrefix, Client::CONFIG_HTTP_CLIENT_BUILDER => $builder]);
         $client->get('/');
         $sent_request = self::$httpClient->getLastRequest();
-        $this->assertEquals("{$userAgentPrefix} ({$client->getClientVersion()}" . "; PHP/" . PHP_VERSION . ")", $sent_request->getHeaderLine('User-Agent'));
+        $this->assertEquals($userAgentPrefix . ' (' . $client->getClientVersion() . '; PHP/' . PHP_VERSION . ')', $sent_request->getHeaderLine('User-Agent'));
     }
 
     public function testRebuildShouldNotRemoveCustomPlugin(): void

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -90,7 +90,7 @@ class ClientTest extends TestCase
         $client = new Client(new NullAuthentication(), null, [Client::CONFIG_USER_AGENT_PREFIX => $userAgentPrefix, Client::CONFIG_HTTP_CLIENT_BUILDER => $builder]);
         $client->get('/');
         $sent_request = self::$httpClient->getLastRequest();
-        $this->assertEquals("{$userAgentPrefix} ({$client->getClientVersion()})", $sent_request->getHeaderLine('User-Agent'));
+        $this->assertEquals("{$userAgentPrefix} ({$client->getClientVersion()}" . "; PHP/" . PHP_VERSION . ")", $sent_request->getHeaderLine('User-Agent'));
     }
 
     public function testRebuildShouldNotRemoveCustomPlugin(): void


### PR DESCRIPTION
Closes https://github.com/apigee/apigee-edge-drupal/issues/556

To implement the UA in the below format :
`Apigee Edge/1.22 (Apigee Edge PHP Client/2.0.3; Drupal/8.9.16; PHP/7.3.11)`
and
`Apigee Monetization/1.10 (Apigee Edge/8.x-1.22; Apigee Edge PHP Client/2.0.3; Drupal/8.9.16; PHP/7.3.11)`

We had to change the `getUserAgent()`, here we are providing more information about Drupal core versions and modules version by exploding the string passed as parameter by Apigee_edge module `userAgentPrefix()`.

Need to make sure about the changes made in library in getUserAgent() function.

