### PR TITLE
Fix InvalidArgument error when running composer analyze

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -314,7 +314,8 @@ class Client implements ClientInterface
         ];
 
         if (null !== $this->retryPluginConfig) {
-            if (!isset($this->retryPluginConfig['exception_decider'])) {
+            $retryPluginConfig = $this->retryPluginConfig;
+            if (!isset($retryPluginConfig['exception_decider'])) {
                 $this->retryPluginConfig['exception_decider'] = function (RequestInterface $request, Exception $e) {
                     // When Oauth authentication is in use retry decider should ignore
                     // OauthAuthenticationException.


### PR DESCRIPTION
Closes #192 
Fix error 
`ERROR: InvalidArgument - src/Client.php:334:48 - Argument 1 of Http\Client\Common\Plugin\RetryPlugin::__construct expects array{error_response_decider?: callable, error_response_delay?: callable, exception_decider?: callable, exception_delay?: callable, retries?: int}, array{exception_decider: impure-Closure(Psr\Http\Message\RequestInterface, Http\Client\Exception):bool|mixed} provided (see https://psalm.dev/004)`