### PR TITLE
Remove uncertified orb and implemented codecov through Curl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@
 # Check https://circleci.com/docs/2.0/language-php/ for more details
 #
 version: 2.1
-orbs: 
-  codecov: codecov/codecov@3.2.2
 defaults: &defaults
   docker:
     - image: cimg/php:<< parameters.php-version >>-node
@@ -74,17 +72,16 @@ php_build: &php_build
     - run:
         name: Composer Metrics
         command: composer metrics
-  
-  # Generate code coverage artifacts and upload to Codecov.
+        
     - when:
         condition: 
             and:
               - equal: [ "7.4", << parameters.php-version >> ]
               - equal: [ " ", << parameters.dependencies >> ]  
         steps:
+           # Generate code coverage artifacts and upload to Codecov.
           - run: phpdbg -d memory_limit=-1 -qrr vendor/bin/phpunit --coverage-html build/coverage-report --coverage-clover coverage.xml
-          - codecov/upload:
-              file: 'coverage.xml'
+          - run: bash <(curl -s https://codecov.io/bash) 
           - store_artifacts:
               path: build/coverage-report
           - store_test_results:


### PR DESCRIPTION
Closes #197 
Remove CircleCI un-certified orb `codecov/codecov@3.2.2` fom config.yml and implement codecov to upload coverage report with Curl.

