### PR TITLE
Replaced CircleCI deprecated bash uploader with Codecov Uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,14 @@ php_build: &php_build
           - run: 
               name: Upload coverage reports to Codecov
               command: |
-                bash <(curl -s https://codecov.io/bash) 
+                  curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+                  curl -Os https://uploader.codecov.io/latest/linux/codecov
+                  curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+                  curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+                  gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+                  shasum -a 256 -c codecov.SHA256SUM
+                  chmod +x codecov
+                  ./codecov -t ${CODECOV_TOKEN}
           - store_artifacts:
               path: build/coverage-report
           - store_test_results:


### PR DESCRIPTION
Closes #197 
Replaced CircleCI deprecated bash uploader code with Codecov Uploader.
Deprecated https://docs.codecov.com/docs/about-the-codecov-bash-uploader
