### PR TITLE
Bump php-http/message requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.6.0",
         "php-http/httplug": "^2.0",
-        "php-http/message": "^1.9",
+        "php-http/message": "^1.13",
         "php-http/message-factory": "^1.0",
         "phpdocumentor/reflection-docblock": "^3.0 || ^4.0 || ^5.0",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
Closes #206 
Bump php-http/message version requirement from 1.9 to 1.13.

Issue reference : https://github.com/apigee/apigee-edge-drupal/issues/667