### PR TITLE
Rolled back the changes because of backwards-incompatible

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -33,11 +33,11 @@ use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
 use Http\Client\Common\Plugin\HistoryPlugin;
 use Http\Client\Common\Plugin\RetryPlugin;
 use Http\Client\Exception;
+use Http\Client\HttpClient;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\UriFactoryDiscovery;
 use Http\Message\Authentication;
 use Http\Message\UriFactory;
-use Psr\Http\Client\ClientInterface as HttpClient;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -47,6 +47,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * Class Client.
  *
  * Default API client implementation for Apigee Edge.
+ *
+ * @psalm-suppress DeprecatedInterface - DeprecatedInterface will be replaced in 3.x branch.
  */
 class Client implements ClientInterface
 {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -19,8 +19,8 @@
 namespace Apigee\Edge;
 
 use Apigee\Edge\HttpClient\Utility\JournalInterface;
+use Http\Client\HttpClient;
 use Http\Message\UriFactory;
-use Psr\Http\Client\ClientInterface as HttpClient;
 use Psr\Http\Message\ResponseInterface;
 
 /**


### PR DESCRIPTION
#265
Issue ref : https://github.com/apigee/apigee-client-php/issues/258#issuecomment-1571881053

Deprecated class `Http\Client\HttpClient` will be replaced with `Psr\Http\Client\ClientInterface` in 3.x branch 