### PR TITLE
Mark psr/http-message >=2.0 supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php-http/message": "^1.13",
         "php-http/message-factory": "^1.0",
         "phpdocumentor/reflection-docblock": "^5.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "symfony/options-resolver": "^6.3",
         "symfony/property-access": "^6.3",
         "symfony/property-info": "^6.3",

--- a/tests/Utility/ResponseToArrayHelperTest.php
+++ b/tests/Utility/ResponseToArrayHelperTest.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Tests\Utility;
 
 use Apigee\Edge\Tests\Test\Utility\ResponseToArrayHelper;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
@@ -50,13 +51,13 @@ class ResponseToArrayHelperTest extends TestCase
         /** @var \Psr\Http\Message\ResponseInterface $response1 */
         $response1 = $this->getMockBuilder(ResponseInterface::class)->getMock();
         $response1->method('getHeaderLine')->willReturn('application/json');
-        $response1->method('getBody')->willReturn($edgeResponse);
+        $response1->method('getBody')->willReturn(Utils::streamFor($edgeResponse));
         $decodedEdgeStyle = $this->responseToArrayHelper->convertResponseToArray($response1, false);
 
         /** @var \Psr\Http\Message\ResponseInterface $response2 */
         $response2 = $this->getMockBuilder(ResponseInterface::class)->getMock();
         $response2->method('getHeaderLine')->willReturn('application/json');
-        $response2->method('getBody')->willReturn($hybridResponse);
+        $response2->method('getBody')->willReturn(Utils::streamFor($hybridResponse));
         $decodedWithCompatibility = $this->responseToArrayHelper->convertResponseToArray($response2, true);
 
         $this->assertEquals($decodedEdgeStyle, $decodedWithCompatibility);


### PR DESCRIPTION
Motivation: Make installation on Apigee Edge module easier on Drupal 10+ projects was built with https://packagist.org/packages/drupal/core-recommended#10.1.3 that depends on https://packagist.org/packages/symfony/psr-http-message-bridge#v2.3.1.

What is the problem? 

When a new clean Drupal 10+ project is created with `drupal/core-recommended` Composer picks the highest version of packages, including psr/http-message and it installs 2.0.0. Later when drupal/apigee_edge module gets installed, Composer needs convincing to downgrade to a previous version of psr/http-message because this package needs that. (Luckily the rest of the dependency chain also support 1.x.)

Related:
* https://www.php-fig.org/psr/psr-7/meta/#72-type-additions --> I was uncertain if we would like to push for parameter typehints or not and symfony/psr-http-message-bridge support 1.0, so I kept that lowest boundery. 