### PR TITLE
Fix error when AppGroup list is empty or do not returns appgroups array - 2x

### DIFF
--- a/src/Api/ApigeeX/Controller/PaginationHelperTrait.php
+++ b/src/Api/ApigeeX/Controller/PaginationHelperTrait.php
@@ -117,7 +117,8 @@ trait PaginationHelperTrait
             // Ignore entity type key from response, ex.: developer, apiproduct,
             // etc.
             $responseArray = reset($responseArray);
-            if (empty($responseArray)) {
+            // Appgroup can be empty.
+            if (empty($responseArray) || !is_array($responseArray)) {
                 return [];
             }
             $entities = $this->responseArrayToArrayOfEntities($responseArray, $key_provider);


### PR DESCRIPTION
Closes https://github.com/apigee/apigee-client-php/issues/325 for 2x