### PR TITLE
Fix attribute values lost in PUT call while creating AppGroup

### DIFF
--- a/src/Api/ApigeeX/Controller/AppGroupMembersController.php
+++ b/src/Api/ApigeeX/Controller/AppGroupMembersController.php
@@ -105,7 +105,9 @@ class AppGroupMembersController extends AbstractController implements AppGroupMe
     }
 
     /**
-     * {@inheritdoc}
+     * Helper function for getting all attributes in AppGroup.
+     *
+     * @return AttributesProperty
      */
     public function getAppGroupAttributes(): AttributesProperty
     {

--- a/src/Api/ApigeeX/Controller/AppGroupMembersController.php
+++ b/src/Api/ApigeeX/Controller/AppGroupMembersController.php
@@ -48,7 +48,7 @@ class AppGroupMembersController extends AbstractController implements AppGroupMe
      *
      * @param string $appGroup
      * @param string $organization
-     * @param \Apigee\Edge\ClientInterface $client
+     * @param ClientInterface $client
      */
     public function __construct(string $appGroup, string $organization, ClientInterface $client)
     {
@@ -115,6 +115,7 @@ class AppGroupMembersController extends AbstractController implements AppGroupMe
             $appGroup['attributes'],
             AttributesProperty::class
         );
+
         return $appGroupAttributes;
     }
 

--- a/src/Api/ApigeeX/Controller/AppGroupMembersController.php
+++ b/src/Api/ApigeeX/Controller/AppGroupMembersController.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\ApigeeX\Controller;
 
 use Apigee\Edge\Api\ApigeeX\Serializer\AppGroupMembershipSerializer;
 use Apigee\Edge\Api\ApigeeX\Structure\AppGroupMembership;
+use Apigee\Edge\Api\Management\Serializer\AttributesPropertyAwareEntitySerializer;
 use Apigee\Edge\ClientInterface;
 use Apigee\Edge\Controller\AbstractController;
 use Apigee\Edge\Controller\OrganizationAwareControllerTrait;
@@ -73,8 +74,10 @@ class AppGroupMembersController extends AbstractController implements AppGroupMe
     public function setMembers(AppGroupMembership $members): AppGroupMembership
     {
         $members = $this->serializer->normalize($members);
-        $apigeeReservedMembers = new AttributesProperty();
 
+        // We don't have a separate API to get appgroup attributes,
+        // that is why we are calling getAppGroupAttributes() method.
+        $apigeeReservedMembers = $this->getAppGroupAttributes();
         // Adding the new members into the attribute.
         $apigeeReservedMembers->add('__apigee_reserved__developer_details', json_encode($members));
         $response = $this->client->put(
@@ -99,6 +102,20 @@ class AppGroupMembersController extends AbstractController implements AppGroupMe
     {
         $encoded = rawurlencode($email);
         $this->client->delete($this->getBaseEndpointUri()->withPath("{$this->getBaseEndpointUri()->getPath()}/{$encoded}"));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAppGroupAttributes(): AttributesProperty
+    {
+        $appGroup = $this->responseToArray($this->client->get($this->getBaseEndpointUri()));
+        $serializer = new AttributesPropertyAwareEntitySerializer();
+        $appGroupAttributes = $serializer->denormalize(
+            $appGroup['attributes'],
+            AttributesProperty::class
+        );
+        return $appGroupAttributes;
     }
 
     /**

--- a/src/Api/ApigeeX/Controller/AppGroupMembersControllerInterface.php
+++ b/src/Api/ApigeeX/Controller/AppGroupMembersControllerInterface.php
@@ -36,7 +36,7 @@ interface AppGroupMembersControllerInterface extends AppGroupAwareControllerInte
     /**
      * List all developers associated with a appgroup.
      *
-     * @return \Apigee\Edge\Api\ApigeeX\Structure\AppGroupMembership
+     * @return AppGroupMembership
      *   Array of developers with their optional roles in the appgroup.
      */
     public function getMembers(): AppGroupMembership;
@@ -47,10 +47,10 @@ interface AppGroupMembersControllerInterface extends AppGroupAwareControllerInte
      * WARNING! If you pass en empty membership object you remove all developers
      * from the appgroup.
      *
-     * @param \Apigee\Edge\Api\ApigeeX\Structure\AppGroupMembership $members
+     * @param AppGroupMembership $members
      *   Membership object with the changes to be applied.
      *
-     * @return \Apigee\Edge\Api\ApigeeX\Structure\AppGroupMembership
+     * @return AppGroupMembership
      *   Membership object with the applied changes, it does not contain all
      *   members. Use getMembers() to retrieve them.
      */

--- a/src/Api/ApigeeX/Controller/AppGroupMembersControllerInterface.php
+++ b/src/Api/ApigeeX/Controller/AppGroupMembersControllerInterface.php
@@ -19,7 +19,6 @@
 namespace Apigee\Edge\Api\ApigeeX\Controller;
 
 use Apigee\Edge\Api\ApigeeX\Structure\AppGroupMembership;
-use Apigee\Edge\Structure\AttributesProperty;
 
 /**
  * Interface AppGroupMembersControllerInterface.

--- a/src/Api/ApigeeX/Controller/AppGroupMembersControllerInterface.php
+++ b/src/Api/ApigeeX/Controller/AppGroupMembersControllerInterface.php
@@ -19,12 +19,20 @@
 namespace Apigee\Edge\Api\ApigeeX\Controller;
 
 use Apigee\Edge\Api\ApigeeX\Structure\AppGroupMembership;
+use Apigee\Edge\Structure\AttributesProperty;
 
 /**
  * Interface AppGroupMembersControllerInterface.
  */
 interface AppGroupMembersControllerInterface extends AppGroupAwareControllerInterface
 {
+    /**
+     * Returns a list of all entity attributes from AppGroup.
+     *
+     * @return AttributesProperty
+     */
+    public function getAppGroupAttributes(): AttributesProperty;
+
     /**
      * List all developers associated with a appgroup.
      *

--- a/src/Api/ApigeeX/Controller/AppGroupMembersControllerInterface.php
+++ b/src/Api/ApigeeX/Controller/AppGroupMembersControllerInterface.php
@@ -27,13 +27,6 @@ use Apigee\Edge\Structure\AttributesProperty;
 interface AppGroupMembersControllerInterface extends AppGroupAwareControllerInterface
 {
     /**
-     * Returns a list of all entity attributes from AppGroup.
-     *
-     * @return AttributesProperty
-     */
-    public function getAppGroupAttributes(): AttributesProperty;
-
-    /**
      * List all developers associated with a appgroup.
      *
      * @return AppGroupMembership


### PR DESCRIPTION
Closes #339 

AppGroup do not have separate API for getting AppGroup attributes so implemented `getAppGroupAttributes()` method interface to get all attributes from AppGroup.