### PR TITLE
Fix for test failing for symfony 6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/options-resolver": "^6.3",
         "symfony/property-access": "^6.3",
         "symfony/property-info": "^6.3",
-        "symfony/serializer": "^6.3"
+        "symfony/serializer": "^6.3.11"
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "^0.4.0",

--- a/tests/Api/Monetization/Denormalizer/ReportCriteriaDenormalizerTest.php
+++ b/tests/Api/Monetization/Denormalizer/ReportCriteriaDenormalizerTest.php
@@ -46,7 +46,7 @@ class ReportCriteriaDenormalizerTest extends TestCase
 
     public function testDenormalizeWithAbtractClassNoContext(): void
     {
-        $this->expectException('\Error');
+        $this->expectException('\Symfony\Component\Serializer\Exception\NotNormalizableValueException');
 
         static::$denormalizer->denormalize((object) [], AbstractCriteria::class, 'json');
     }

--- a/tests/Api/Monetization/Denormalizer/ReportCriteriaDenormalizerTest.php
+++ b/tests/Api/Monetization/Denormalizer/ReportCriteriaDenormalizerTest.php
@@ -31,7 +31,7 @@ use Symfony\Component\Serializer\Serializer;
 
 class ReportCriteriaDenormalizerTest extends TestCase
 {
-    /** @var \Apigee\Edge\Api\Monetization\Denormalizer\ReportCriteriaDenormalizer */
+    /** @var Apigee\Edge\Api\Monetization\Denormalizer\ReportCriteriaDenormalizer */
     protected static $denormalizer;
 
     /**


### PR DESCRIPTION
Closes #341 
Serializer/Normalizer/AbstractNormalizer changed the exception type for Abstract class instantiate check. 
As this check was introduced in symfony 6.3.11 , symfony/serialiser version is bumped.