### PR TITLE
Fix for composer analyze failing in github action

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "phpunit/phpunit": "^9.6",
         "sebastian/comparator": "^4.0.5",
         "symfony/cache": "^6.3",
-        "vimeo/psalm": "^5.12"
+        "vimeo/psalm": "^5.20"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -52,5 +52,8 @@
 
         <!-- Disable error caused by deprecated interface-->
         <DeprecatedInterface errorLevel="info" />
+
+        <RiskyTruthyFalsyComparison errorLevel="info" />
+        
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
Closes #348 
For now have added errorLevel as 'info' to skip RiskyTruthyFalsyComparison error while running composer analyze. Also upgraded vimeo/psalm version to latest as this error was adding in the latest release.