### PR TITLE
Remove symfony/serializer conflict and bump version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
         "php-http/message-factory": "^1.0",
         "phpdocumentor/reflection-docblock": "^5.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "symfony/options-resolver": "^6.4.6",
-        "symfony/property-access": "^6.4.6",
-        "symfony/property-info": "^6.4.6",
-        "symfony/serializer": "^6.4.6"
+        "symfony/options-resolver": "^6.4.9",
+        "symfony/property-access": "^6.4.9",
+        "symfony/property-info": "^6.4.9",
+        "symfony/serializer": "^6.4.9"
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "^0.4.0",
@@ -46,11 +46,8 @@
         "phpmetrics/phpmetrics": "^2.7",
         "phpunit/phpunit": "^9.6",
         "sebastian/comparator": "^4.0.5",
-        "symfony/cache": "^6.4.6",
+        "symfony/cache": "^6.4.9",
         "vimeo/psalm": "^5.20"
-    },
-    "conflict": {
-        "symfony/serializer": ">6.4.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/Api/Monetization/Structure/Reports/Criteria/AbstractCriteria.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/AbstractCriteria.php
@@ -22,7 +22,7 @@ use Apigee\Edge\Structure\ObjectCopyHelperTrait;
 
 /**
  * Base class for all supported Monetization reports.
- * 
+ *
  * @internal
  *
  * @see https://docs.apigee.com/api-platform/monetization/create-reports#repdefconfigapi
@@ -119,7 +119,7 @@ abstract class AbstractCriteria
     /**
      * @param string ...$appIds
      *
-     * @return \self
+     * @return self
      */
     public function setApps(string ...$appIds): self
     {
@@ -139,7 +139,7 @@ abstract class AbstractCriteria
     /**
      * @param string ...$currencyIds
      *
-     * @return \self
+     * @return self
      */
     public function setCurrencies(string ...$currencyIds): self
     {
@@ -159,7 +159,7 @@ abstract class AbstractCriteria
     /**
      * @param string|null $currencyOption
      *
-     * @return \self
+     * @return self
      */
     public function setCurrencyOption(?string $currencyOption): self
     {
@@ -173,7 +173,7 @@ abstract class AbstractCriteria
     /**
      * @param string ...$developerIds
      *
-     * @return \self
+     * @return self
      */
     public function setDevelopers(string ...$developerIds): self
     {
@@ -201,7 +201,7 @@ abstract class AbstractCriteria
     /**
      * @param string ...$apiPackageIds
      *
-     * @return \self
+     * @return self
      */
     public function setApiPackages(string ...$apiPackageIds): self
     {
@@ -221,7 +221,7 @@ abstract class AbstractCriteria
     /**
      * @param string ...$apiProductIds
      *
-     * @return \self
+     * @return self
      */
     public function setApiProducts(string ...$apiProductIds): self
     {
@@ -241,7 +241,7 @@ abstract class AbstractCriteria
     /**
      * @param string ...$pricingTypes
      *
-     * @return \self
+     * @return self
      */
     public function setPricingTypes(string ...$pricingTypes): self
     {
@@ -261,7 +261,7 @@ abstract class AbstractCriteria
     /**
      * @param string ...$ratePlanLevels
      *
-     * @return \self
+     * @return self
      */
     public function setRatePlanLevels(string ...$ratePlanLevels): self
     {
@@ -305,7 +305,7 @@ abstract class AbstractCriteria
     /**
      * @param bool $show
      *
-     * @return \self
+     * @return self
      */
     public function setShowRevenueSharePercentage(bool $show): self
     {
@@ -317,7 +317,7 @@ abstract class AbstractCriteria
     /**
      * @param bool $show
      *
-     * @return \self
+     * @return self
      */
     public function setShowSummary(bool $show): self
     {
@@ -329,7 +329,7 @@ abstract class AbstractCriteria
     /**
      * @param bool $show
      *
-     * @return \self
+     * @return self
      */
     public function setShowTransactionDetail(bool $show): self
     {
@@ -341,7 +341,7 @@ abstract class AbstractCriteria
     /**
      * @param bool $show
      *
-     * @return \self
+     * @return self
      */
     public function setShowTransactionType(bool $show): self
     {

--- a/src/Api/Monetization/Structure/Reports/Criteria/AbstractCriteria.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/AbstractCriteria.php
@@ -126,9 +126,8 @@ abstract class AbstractCriteria
      */
     public function apps(string ...$appIds): self
     {
-        $this->apps = $appIds;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setApps() instead.', E_USER_DEPRECATED);
+        return $this->setApps(...$appIds);
     }
 
     /**
@@ -161,9 +160,8 @@ abstract class AbstractCriteria
      */
     public function currencies(string ...$currencyIds): self
     {
-        $this->currencies = $currencyIds;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setCurrencies() instead.', E_USER_DEPRECATED);
+        return $this->setCurrencies(...$currencyIds);
     }
 
     /**
@@ -198,9 +196,8 @@ abstract class AbstractCriteria
     {
         // This tweak allows to reset the previously configured currency option
         // by calling this method with an empty string or null.
-        $this->currencyOption = $currencyOption;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setCurrencyOption() instead.', E_USER_DEPRECATED);
+        return $this->setCurrencyOption($currencyOption);
     }
 
     /**
@@ -227,9 +224,8 @@ abstract class AbstractCriteria
      */
     public function developers(string ...$developerIds): self
     {
-        $this->developers = $developerIds;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setDevelopers() instead.', E_USER_DEPRECATED);
+        return $this->setDevelopers(...$developerIds);
     }
 
     /**
@@ -270,9 +266,8 @@ abstract class AbstractCriteria
      */
     public function apiPackages(string ...$apiPackageIds): self
     {
-        $this->apiPackages = $apiPackageIds;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setApiPackages() instead.', E_USER_DEPRECATED);
+        return $this->setApiPackages(...$apiPackageIds);
     }
 
     /**
@@ -305,9 +300,8 @@ abstract class AbstractCriteria
      */
     public function apiProducts(string ...$apiProductIds): self
     {
-        $this->apiProducts = $apiProductIds;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setApiProducts() instead.', E_USER_DEPRECATED);
+        return $this->setApiProducts(...$apiProductIds);
     }
 
     /**
@@ -340,9 +334,8 @@ abstract class AbstractCriteria
      */
     public function pricingTypes(string ...$pricingTypes): self
     {
-        $this->pricingTypes = $pricingTypes;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setPricingTypes() instead.', E_USER_DEPRECATED);
+        return $this->setPricingTypes(...$pricingTypes);
     }
 
     /**
@@ -375,9 +368,8 @@ abstract class AbstractCriteria
      */
     public function ratePlanLevels(string ...$ratePlanLevels): self
     {
-        $this->ratePlanLevels = $ratePlanLevels;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setRatePlanLevels() instead.', E_USER_DEPRECATED);
+        return $this->setRatePlanLevels(...$ratePlanLevels);
     }
 
     /**
@@ -434,9 +426,8 @@ abstract class AbstractCriteria
      */
     public function showRevenueSharePercentage(bool $show): self
     {
-        $this->showRevenueSharePercentage = $show;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setShowRevenueSharePercentage() instead.', E_USER_DEPRECATED);
+        return $this->setShowRevenueSharePercentage($show);
     }
 
     /**
@@ -461,9 +452,8 @@ abstract class AbstractCriteria
      */
     public function showSummary(bool $show): self
     {
-        $this->showSummary = $show;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setShowSummary() instead.', E_USER_DEPRECATED);
+        return $this->setShowSummary($show);
     }
 
     /**
@@ -488,9 +478,8 @@ abstract class AbstractCriteria
      */
     public function showTransactionDetail(bool $show): self
     {
-        $this->showTransactionDetail = $show;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setShowTransactionDetail() instead.', E_USER_DEPRECATED);
+        return $this->setShowTransactionDetail($show);
     }
 
     /**
@@ -515,9 +504,8 @@ abstract class AbstractCriteria
      */
     public function showTransactionType(bool $show): self
     {
-        $this->showTransactionType = $show;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setShowTransactionType() instead.', E_USER_DEPRECATED);
+        return $this->setShowTransactionType($show);
     }
 
     /**

--- a/src/Api/Monetization/Structure/Reports/Criteria/AbstractCriteria.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/AbstractCriteria.php
@@ -120,6 +120,21 @@ abstract class AbstractCriteria
      * @param string ...$appIds
      *
      * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function apps(string ...$appIds): self
+    {
+        $this->apps = $appIds;
+
+        return $this;
+    }
+
+    /**
+     * @param string ...$appIds
+     *
+     * @return self
      */
     public function setApps(string ...$appIds): self
     {
@@ -134,6 +149,21 @@ abstract class AbstractCriteria
     public function getCurrencies(): array
     {
         return $this->currencies;
+    }
+
+    /**
+     * @param string ...$currencyIds
+     *
+     * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function currencies(string ...$currencyIds): self
+    {
+        $this->currencies = $currencyIds;
+
+        return $this;
     }
 
     /**
@@ -160,12 +190,44 @@ abstract class AbstractCriteria
      * @param string|null $currencyOption
      *
      * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function currencyOption(?string $currencyOption): self
+    {
+        // This tweak allows to reset the previously configured currency option
+        // by calling this method with an empty string or null.
+        $this->currencyOption = $currencyOption;
+
+        return $this;
+    }
+
+    /**
+     * @param string|null $currencyOption
+     *
+     * @return self
      */
     public function setCurrencyOption(?string $currencyOption): self
     {
         // This tweak allows to reset the previously configured currency option
         // by calling this method with an empty string or null.
         $this->currencyOption = $currencyOption;
+
+        return $this;
+    }
+
+    /**
+     * @param string ...$developerIds
+     *
+     * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function developers(string ...$developerIds): self
+    {
+        $this->developers = $developerIds;
 
         return $this;
     }
@@ -202,6 +264,21 @@ abstract class AbstractCriteria
      * @param string ...$apiPackageIds
      *
      * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function apiPackages(string ...$apiPackageIds): self
+    {
+        $this->apiPackages = $apiPackageIds;
+
+        return $this;
+    }
+
+    /**
+     * @param string ...$apiPackageIds
+     *
+     * @return self
      */
     public function setApiPackages(string ...$apiPackageIds): self
     {
@@ -216,6 +293,21 @@ abstract class AbstractCriteria
     public function getApiProducts(): array
     {
         return $this->apiProducts;
+    }
+
+    /**
+     * @param string ...$apiProductIds
+     *
+     * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function apiProducts(string ...$apiProductIds): self
+    {
+        $this->apiProducts = $apiProductIds;
+
+        return $this;
     }
 
     /**
@@ -242,6 +334,21 @@ abstract class AbstractCriteria
      * @param string ...$pricingTypes
      *
      * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function pricingTypes(string ...$pricingTypes): self
+    {
+        $this->pricingTypes = $pricingTypes;
+
+        return $this;
+    }
+
+    /**
+     * @param string ...$pricingTypes
+     *
+     * @return self
      */
     public function setPricingTypes(string ...$pricingTypes): self
     {
@@ -256,6 +363,21 @@ abstract class AbstractCriteria
     public function getRatePlanLevels(): array
     {
         return $this->ratePlanLevels;
+    }
+
+    /**
+     * @param string ...$ratePlanLevels
+     *
+     * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function ratePlanLevels(string ...$ratePlanLevels): self
+    {
+        $this->ratePlanLevels = $ratePlanLevels;
+
+        return $this;
     }
 
     /**
@@ -306,10 +428,40 @@ abstract class AbstractCriteria
      * @param bool $show
      *
      * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function showRevenueSharePercentage(bool $show): self
+    {
+        $this->showRevenueSharePercentage = $show;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $show
+     *
+     * @return self
      */
     public function setShowRevenueSharePercentage(bool $show): self
     {
         $this->showRevenueSharePercentage = $show;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $show
+     *
+     * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function showSummary(bool $show): self
+    {
+        $this->showSummary = $show;
 
         return $this;
     }
@@ -330,10 +482,40 @@ abstract class AbstractCriteria
      * @param bool $show
      *
      * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function showTransactionDetail(bool $show): self
+    {
+        $this->showTransactionDetail = $show;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $show
+     *
+     * @return self
      */
     public function setShowTransactionDetail(bool $show): self
     {
         $this->showTransactionDetail = $show;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $show
+     *
+     * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function showTransactionType(bool $show): self
+    {
+        $this->showTransactionType = $show;
 
         return $this;
     }

--- a/src/Api/Monetization/Structure/Reports/Criteria/AbstractCriteria.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/AbstractCriteria.php
@@ -22,13 +22,7 @@ use Apigee\Edge\Structure\ObjectCopyHelperTrait;
 
 /**
  * Base class for all supported Monetization reports.
- *
- * Boolean getters must be prefixed with "get" instead of "is" because
- * property accessor tries to call property name (without prefix) earlier
- * than "is" . ucfirst('propertyName') - which is a setter method here.
- *
- * @see https://github.com/symfony/property-access/blob/v4.2.5/PropertyAccessor.php#L433-L435
- *
+ * 
  * @internal
  *
  * @see https://docs.apigee.com/api-platform/monetization/create-reports#repdefconfigapi
@@ -127,7 +121,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function apps(string ...$appIds): self
+    public function setApps(string ...$appIds): self
     {
         $this->apps = $appIds;
 
@@ -147,7 +141,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function currencies(string ...$currencyIds): self
+    public function setCurrencies(string ...$currencyIds): self
     {
         $this->currencies = $currencyIds;
 
@@ -167,7 +161,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function currencyOption(?string $currencyOption): self
+    public function setCurrencyOption(?string $currencyOption): self
     {
         // This tweak allows to reset the previously configured currency option
         // by calling this method with an empty string or null.
@@ -181,7 +175,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function developers(string ...$developerIds): self
+    public function setDevelopers(string ...$developerIds): self
     {
         $this->developers = $developerIds;
 
@@ -209,7 +203,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function apiPackages(string ...$apiPackageIds): self
+    public function setApiPackages(string ...$apiPackageIds): self
     {
         $this->apiPackages = $apiPackageIds;
 
@@ -229,7 +223,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function apiProducts(string ...$apiProductIds): self
+    public function setApiProducts(string ...$apiProductIds): self
     {
         $this->apiProducts = $apiProductIds;
 
@@ -249,7 +243,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function pricingTypes(string ...$pricingTypes): self
+    public function setPricingTypes(string ...$pricingTypes): self
     {
         $this->pricingTypes = $pricingTypes;
 
@@ -269,7 +263,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function ratePlanLevels(string ...$ratePlanLevels): self
+    public function setRatePlanLevels(string ...$ratePlanLevels): self
     {
         $this->ratePlanLevels = $ratePlanLevels;
 
@@ -313,7 +307,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function showRevenueSharePercentage(bool $show): self
+    public function setShowRevenueSharePercentage(bool $show): self
     {
         $this->showRevenueSharePercentage = $show;
 
@@ -325,7 +319,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function showSummary(bool $show): self
+    public function setShowSummary(bool $show): self
     {
         $this->showSummary = $show;
 
@@ -337,7 +331,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function showTransactionDetail(bool $show): self
+    public function setShowTransactionDetail(bool $show): self
     {
         $this->showTransactionDetail = $show;
 
@@ -349,7 +343,7 @@ abstract class AbstractCriteria
      *
      * @return \self
      */
-    public function showTransactionType(bool $show): self
+    public function setShowTransactionType(bool $show): self
     {
         $this->showTransactionType = $show;
 

--- a/src/Api/Monetization/Structure/Reports/Criteria/AbstractCriteria.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/AbstractCriteria.php
@@ -127,6 +127,7 @@ abstract class AbstractCriteria
     public function apps(string ...$appIds): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setApps() instead.', E_USER_DEPRECATED);
+
         return $this->setApps(...$appIds);
     }
 
@@ -161,6 +162,7 @@ abstract class AbstractCriteria
     public function currencies(string ...$currencyIds): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setCurrencies() instead.', E_USER_DEPRECATED);
+
         return $this->setCurrencies(...$currencyIds);
     }
 
@@ -197,6 +199,7 @@ abstract class AbstractCriteria
         // This tweak allows to reset the previously configured currency option
         // by calling this method with an empty string or null.
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setCurrencyOption() instead.', E_USER_DEPRECATED);
+
         return $this->setCurrencyOption($currencyOption);
     }
 
@@ -225,6 +228,7 @@ abstract class AbstractCriteria
     public function developers(string ...$developerIds): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setDevelopers() instead.', E_USER_DEPRECATED);
+
         return $this->setDevelopers(...$developerIds);
     }
 
@@ -267,6 +271,7 @@ abstract class AbstractCriteria
     public function apiPackages(string ...$apiPackageIds): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setApiPackages() instead.', E_USER_DEPRECATED);
+
         return $this->setApiPackages(...$apiPackageIds);
     }
 
@@ -301,6 +306,7 @@ abstract class AbstractCriteria
     public function apiProducts(string ...$apiProductIds): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setApiProducts() instead.', E_USER_DEPRECATED);
+
         return $this->setApiProducts(...$apiProductIds);
     }
 
@@ -335,6 +341,7 @@ abstract class AbstractCriteria
     public function pricingTypes(string ...$pricingTypes): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setPricingTypes() instead.', E_USER_DEPRECATED);
+
         return $this->setPricingTypes(...$pricingTypes);
     }
 
@@ -369,6 +376,7 @@ abstract class AbstractCriteria
     public function ratePlanLevels(string ...$ratePlanLevels): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setRatePlanLevels() instead.', E_USER_DEPRECATED);
+
         return $this->setRatePlanLevels(...$ratePlanLevels);
     }
 
@@ -427,6 +435,7 @@ abstract class AbstractCriteria
     public function showRevenueSharePercentage(bool $show): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setShowRevenueSharePercentage() instead.', E_USER_DEPRECATED);
+
         return $this->setShowRevenueSharePercentage($show);
     }
 
@@ -453,6 +462,7 @@ abstract class AbstractCriteria
     public function showSummary(bool $show): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setShowSummary() instead.', E_USER_DEPRECATED);
+
         return $this->setShowSummary($show);
     }
 
@@ -479,6 +489,7 @@ abstract class AbstractCriteria
     public function showTransactionDetail(bool $show): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setShowTransactionDetail() instead.', E_USER_DEPRECATED);
+
         return $this->setShowTransactionDetail($show);
     }
 
@@ -505,6 +516,7 @@ abstract class AbstractCriteria
     public function showTransactionType(bool $show): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setShowTransactionType() instead.', E_USER_DEPRECATED);
+
         return $this->setShowTransactionType($show);
     }
 

--- a/src/Api/Monetization/Structure/Reports/Criteria/GroupByCriteriaTrait.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/GroupByCriteriaTrait.php
@@ -35,6 +35,21 @@ trait GroupByCriteriaTrait
      * @param string ...$groupBy
      *
      * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function groupBy(string ...$groupBy): self
+    {
+        $this->groupBy = $groupBy;
+
+        return $this;
+    }
+
+    /**
+     * @param string ...$groupBy
+     *
+     * @return self
      */
     public function setGroupBy(string ...$groupBy): self
     {

--- a/src/Api/Monetization/Structure/Reports/Criteria/GroupByCriteriaTrait.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/GroupByCriteriaTrait.php
@@ -41,9 +41,8 @@ trait GroupByCriteriaTrait
      */
     public function groupBy(string ...$groupBy): self
     {
-        $this->groupBy = $groupBy;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setGroupBy() instead.', E_USER_DEPRECATED);
+        return $this->setGroupBy(...$groupBy);
     }
 
     /**

--- a/src/Api/Monetization/Structure/Reports/Criteria/GroupByCriteriaTrait.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/GroupByCriteriaTrait.php
@@ -42,6 +42,7 @@ trait GroupByCriteriaTrait
     public function groupBy(string ...$groupBy): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setGroupBy() instead.', E_USER_DEPRECATED);
+
         return $this->setGroupBy(...$groupBy);
     }
 

--- a/src/Api/Monetization/Structure/Reports/Criteria/GroupByCriteriaTrait.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/GroupByCriteriaTrait.php
@@ -34,7 +34,7 @@ trait GroupByCriteriaTrait
     /**
      * @param string ...$groupBy
      *
-     * @return \self
+     * @return self
      */
     public function setGroupBy(string ...$groupBy): self
     {

--- a/src/Api/Monetization/Structure/Reports/Criteria/GroupByCriteriaTrait.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/GroupByCriteriaTrait.php
@@ -36,7 +36,7 @@ trait GroupByCriteriaTrait
      *
      * @return \self
      */
-    public function groupBy(string ...$groupBy): self
+    public function setGroupBy(string ...$groupBy): self
     {
         $this->groupBy = $groupBy;
 

--- a/src/Api/Monetization/Structure/Reports/Criteria/TransactionTypesCriteriaTrait.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/TransactionTypesCriteriaTrait.php
@@ -38,7 +38,7 @@ trait TransactionTypesCriteriaTrait
      *
      * @return \self
      */
-    public function transactionTypes(string ...$transactionTypes): self
+    public function setTransactionTypes(string ...$transactionTypes): self
     {
         $this->transactionTypes = $transactionTypes;
 

--- a/src/Api/Monetization/Structure/Reports/Criteria/TransactionTypesCriteriaTrait.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/TransactionTypesCriteriaTrait.php
@@ -36,7 +36,7 @@ trait TransactionTypesCriteriaTrait
     /**
      * @param string ...$transactionTypes
      *
-     * @return \self
+     * @return self
      */
     public function setTransactionTypes(string ...$transactionTypes): self
     {

--- a/src/Api/Monetization/Structure/Reports/Criteria/TransactionTypesCriteriaTrait.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/TransactionTypesCriteriaTrait.php
@@ -37,6 +37,21 @@ trait TransactionTypesCriteriaTrait
      * @param string ...$transactionTypes
      *
      * @return self
+     *
+     * @deprecated in 3.0.7, will be removed in 4.0.0. No longer needed.
+     * https://github.com/apigee/apigee-client-php/issues/373
+     */
+    public function transactionTypes(string ...$transactionTypes): self
+    {
+        $this->transactionTypes = $transactionTypes;
+
+        return $this;
+    }
+
+    /**
+     * @param string ...$transactionTypes
+     *
+     * @return self
      */
     public function setTransactionTypes(string ...$transactionTypes): self
     {

--- a/src/Api/Monetization/Structure/Reports/Criteria/TransactionTypesCriteriaTrait.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/TransactionTypesCriteriaTrait.php
@@ -43,9 +43,8 @@ trait TransactionTypesCriteriaTrait
      */
     public function transactionTypes(string ...$transactionTypes): self
     {
-        $this->transactionTypes = $transactionTypes;
-
-        return $this;
+        trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setTransactionTypes() instead.', E_USER_DEPRECATED);
+        return $this->setTransactionTypes(...$transactionTypes);
     }
 
     /**

--- a/src/Api/Monetization/Structure/Reports/Criteria/TransactionTypesCriteriaTrait.php
+++ b/src/Api/Monetization/Structure/Reports/Criteria/TransactionTypesCriteriaTrait.php
@@ -44,6 +44,7 @@ trait TransactionTypesCriteriaTrait
     public function transactionTypes(string ...$transactionTypes): self
     {
         trigger_error(__METHOD__ . ' is deprecated in 3.0.7, will be removed in 4.0.0: use setTransactionTypes() instead.', E_USER_DEPRECATED);
+
         return $this->setTransactionTypes(...$transactionTypes);
     }
 

--- a/tests/Api/Monetization/Entity/ReportDefinitionEntityProviderTrait.php
+++ b/tests/Api/Monetization/Entity/ReportDefinitionEntityProviderTrait.php
@@ -44,7 +44,7 @@ trait ReportDefinitionEntityProviderTrait
     {
         $updated = clone $existing;
         $updated->setDescription($randomData ? static::randomGenerator()->text() : '(edited) test report definition provider');
-        /** @var \Apigee\Edge\Api\Monetization\Structure\Reports\Criteria\BillingReportCriteria $criteria */
+        /** @var BillingReportCriteria $criteria */
         $criteria = $updated->getCriteria();
         $criteria->setBillingMonth('FEBRUARY');
         $criteria->setShowSummary(!$criteria->getShowSummary());

--- a/tests/Api/Monetization/Entity/ReportDefinitionEntityProviderTrait.php
+++ b/tests/Api/Monetization/Entity/ReportDefinitionEntityProviderTrait.php
@@ -30,7 +30,7 @@ trait ReportDefinitionEntityProviderTrait
     protected static function getNewReportDefinition(bool $randomData = true): ReportDefinitionInterface
     {
         $criteria = new BillingReportCriteria('JANUARY', $randomData ? date('Y') : 2019);
-        $criteria->groupBy('PACKAGE', 'PRODUCT', 'DEVELOPER')->ratePlanLevels('STANDARD', 'DEVELOPER')->developers('developer@example.com');
+        $criteria->setGroupBy('PACKAGE', 'PRODUCT', 'DEVELOPER')->setRatePlanLevels('STANDARD', 'DEVELOPER')->setDevelopers('developer@example.com');
         $entity = new ReportDefinition([
             'name' => $randomData ? static::randomGenerator()->machineName() : 'PHPUnit',
             'description' => $randomData ? static::randomGenerator()->text() : 'test report definition provider',
@@ -47,7 +47,7 @@ trait ReportDefinitionEntityProviderTrait
         /** @var \Apigee\Edge\Api\Monetization\Structure\Reports\Criteria\BillingReportCriteria $criteria */
         $criteria = $updated->getCriteria();
         $criteria->setBillingMonth('FEBRUARY');
-        $criteria->showSummary(!$criteria->getShowSummary());
+        $criteria->setShowSummary(!$criteria->getShowSummary());
         $updated->setCriteria($criteria);
 
         return $updated;


### PR DESCRIPTION
Closes #373

In `symfony/serializer:>6.4.6` 

> $context['_read_attributes'] = false;

 prevents the attributes' values from being read if the attribute setters are not implemented.
Ref : https://github.com/symfony/symfony/blob/5df912c9786c53f413c2604b3f979461a36486c5/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php#L312

Now, we added setters for attributes that were previously not included because of this
https://github.com/symfony/property-access/blob/v4.2.5/PropertyAccessor.php#L433-L435