### PR TITLE
Fixes issue of Method normalize with return type '' is different to return type 'ArrayObject|array<array-key, mixed>|null|scalar' of inherited method NormalizerInterface::normalize

### DIFF
--- a/.github/workflows/php-test-workflow.yml
+++ b/.github/workflows/php-test-workflow.yml
@@ -11,10 +11,6 @@ jobs:
         strategy:
             matrix:
                 include:
-                -   php: '8.1'
-                    dependencies-preference: " "
-                -   php: '8.1'
-                    dependencies-preference: "--prefer-lowest"
                 -   php: '8.2'
                     dependencies-preference: " "
                 -   php: '8.2'

--- a/.github/workflows/php-test-workflow.yml
+++ b/.github/workflows/php-test-workflow.yml
@@ -11,6 +11,10 @@ jobs:
         strategy:
             matrix:
                 include:
+                -   php: '8.1'
+                    dependencies-preference: " "
+                -   php: '8.1'
+                    dependencies-preference: "--prefer-lowest"
                 -   php: '8.2'
                     dependencies-preference: " "
                 -   php: '8.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## [3.0.8](https://github.com/apigee/apigee-client-php/milestone/32?closed=1)
+* [#379] Update option-resolver's symfony component version to its latest.
+
 ## [3.0.7](https://github.com/apigee/apigee-client-php/milestone/31?closed=1)
 * [#374] Bump minimum required version of symfony/serializer.
 * [#376] Remove symfony/serializer conflict and bump version.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "http://github.com/apigee/apigee-client-php",
     "license": "Apache-2.0",
     "require": {
-        "php": "~8.2 || ~8.3",
+        "php": "~8.1 || ~8.2 || ~8.3",
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-reflection": "*",
@@ -28,10 +28,10 @@
         "php-http/message-factory": "^1.0",
         "phpdocumentor/reflection-docblock": "^5.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "symfony/options-resolver": "^7.1",
-        "symfony/property-access": "^7.1",
-        "symfony/property-info": "^7.1",
-        "symfony/serializer": "^7.1"
+        "symfony/options-resolver": "^6.4.8",
+        "symfony/property-access": "^6.4.9",
+        "symfony/property-info": "^6.4.9",
+        "symfony/serializer": "^6.4.9"
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "^0.4.0",
@@ -46,7 +46,7 @@
         "phpmetrics/phpmetrics": "^2.7",
         "phpunit/phpunit": "^9.6",
         "sebastian/comparator": "^4.0.5",
-        "symfony/cache": "^7.1",
+        "symfony/cache": "^6.4.9",
         "vimeo/psalm": "^5.20"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "http://github.com/apigee/apigee-client-php",
     "license": "Apache-2.0",
     "require": {
-        "php": "~8.1 || ~8.2 || ~8.3",
+        "php": "~8.2 || ~8.3",
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-reflection": "*",
@@ -28,10 +28,10 @@
         "php-http/message-factory": "^1.0",
         "phpdocumentor/reflection-docblock": "^5.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "symfony/options-resolver": "^6.4.8",
-        "symfony/property-access": "^6.4.9",
-        "symfony/property-info": "^6.4.9",
-        "symfony/serializer": "^6.4.9"
+        "symfony/options-resolver": "^7.1",
+        "symfony/property-access": "^7.1",
+        "symfony/property-info": "^7.1",
+        "symfony/serializer": "^7.1"
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "^0.4.0",
@@ -46,7 +46,7 @@
         "phpmetrics/phpmetrics": "^2.7",
         "phpunit/phpunit": "^9.6",
         "sebastian/comparator": "^4.0.5",
-        "symfony/cache": "^6.4.9",
+        "symfony/cache": "^7.1",
         "vimeo/psalm": "^5.20"
     },
     "autoload": {

--- a/src/Api/ApigeeX/Normalizer/AcceptedRatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AcceptedRatePlanNormalizer.php
@@ -32,7 +32,7 @@ class AcceptedRatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var AcceptedRatePlanInterface $object */
         /** @var object $normalized */

--- a/src/Api/ApigeeX/Normalizer/AcceptedRatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AcceptedRatePlanNormalizer.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\ApigeeX\Entity\AcceptedRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
+use ArrayObject;
 
 class AcceptedRatePlanNormalizer extends EntityNormalizer
 {
@@ -32,7 +33,7 @@ class AcceptedRatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var AcceptedRatePlanInterface $object */
         /** @var object $normalized */

--- a/src/Api/ApigeeX/Normalizer/ApiProductNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/ApiProductNormalizer.php
@@ -48,7 +48,7 @@ class ApiProductNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalized = parent::normalize($object, $format, $context);
 

--- a/src/Api/ApigeeX/Normalizer/ApiProductNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/ApiProductNormalizer.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\ApigeeX\Entity\ApiProductInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\ApiPackageNameConverter;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -48,7 +49,7 @@ class ApiProductNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $normalized = parent::normalize($object, $format, $context);
 

--- a/src/Api/ApigeeX/Normalizer/AppGroupMembershipNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AppGroupMembershipNormalizer.php
@@ -29,7 +29,7 @@ class AppGroupMembershipNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalized = [];
 

--- a/src/Api/ApigeeX/Normalizer/AppGroupMembershipNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AppGroupMembershipNormalizer.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\ApigeeX\Structure\AppGroupMembership;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class AppGroupMembershipNormalizer implements NormalizerInterface
@@ -29,7 +30,7 @@ class AppGroupMembershipNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $normalized = [];
 

--- a/src/Api/ApigeeX/Normalizer/AppNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AppNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\Management\Entity\AppInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -41,7 +42,7 @@ class AppNormalizer extends ObjectNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/AppNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AppNormalizer.php
@@ -41,7 +41,7 @@ class AppNormalizer extends ObjectNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/BillingTypeNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/BillingTypeNormalizer.php
@@ -29,7 +29,7 @@ class BillingTypeNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var BillingTypeInterface $object */
         /** @var object $normalized */

--- a/src/Api/ApigeeX/Normalizer/BillingTypeNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/BillingTypeNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\ApigeeX\Entity\BillingTypeInterface;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
+use ArrayObject;
 
 class BillingTypeNormalizer extends EntityNormalizer
 {
@@ -29,7 +30,7 @@ class BillingTypeNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var BillingTypeInterface $object */
         /** @var object $normalized */

--- a/src/Api/ApigeeX/Normalizer/RatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanNormalizer.php
@@ -52,7 +52,7 @@ abstract class RatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/RatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanNormalizer.php
@@ -23,6 +23,7 @@ use Apigee\Edge\Api\ApigeeX\NameConverter\RatePlanNameConverter;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Exception\UninitializedPropertyException;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -52,7 +53,7 @@ abstract class RatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/RatePlanNormalizerFactory.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanNormalizerFactory.php
@@ -56,7 +56,7 @@ class RatePlanNormalizerFactory implements NormalizerInterface, SerializerAwareI
      * @psalm-suppress InvalidNullableReturnType - There are going to be at
      * least one normalizer always that can normalize data here.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         foreach ($this->normalizers as $normalizer) {
             // Return the result from the first denormalizer that can

--- a/src/Api/ApigeeX/Normalizer/RatePlanNormalizerFactory.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanNormalizerFactory.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\Monetization\Normalizer\CompanyRatePlanNormalizer;
 use Apigee\Edge\Api\Monetization\Normalizer\DeveloperCategoryRatePlanNormalizer;
 use Apigee\Edge\Api\Monetization\Normalizer\DeveloperRatePlanNormalizer;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
@@ -56,7 +57,7 @@ class RatePlanNormalizerFactory implements NormalizerInterface, SerializerAwareI
      * @psalm-suppress InvalidNullableReturnType - There are going to be at
      * least one normalizer always that can normalize data here.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         foreach ($this->normalizers as $normalizer) {
             // Return the result from the first denormalizer that can

--- a/src/Api/ApigeeX/Normalizer/RatePlanRateNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanRateNormalizer.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRate;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRateRevShare;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 
 class RatePlanRateNormalizer extends ObjectNormalizer
 {
@@ -30,7 +31,7 @@ class RatePlanRateNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/RatePlanRateNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanRateNormalizer.php
@@ -30,7 +30,7 @@ class RatePlanRateNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/StandardRatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/StandardRatePlanNormalizer.php
@@ -29,7 +29,7 @@ class StandardRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/StandardRatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/StandardRatePlanNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\ApigeeX\Entity\RatePlanInterface;
 use Apigee\Edge\Api\ApigeeX\Entity\StandardRatePlanInterface;
+use ArrayObject;
 
 class StandardRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -29,7 +30,7 @@ class StandardRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Management/Normalizer/AppCredentialNormalizer.php
+++ b/src/Api/Management/Normalizer/AppCredentialNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Management\Normalizer;
 
 use Apigee\Edge\Api\Management\Entity\AppCredentialInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -41,7 +42,7 @@ class AppCredentialNormalizer extends ObjectNormalizer implements NormalizerInte
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Management/Normalizer/AppCredentialNormalizer.php
+++ b/src/Api/Management/Normalizer/AppCredentialNormalizer.php
@@ -41,7 +41,7 @@ class AppCredentialNormalizer extends ObjectNormalizer implements NormalizerInte
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Management/Normalizer/AppNormalizer.php
+++ b/src/Api/Management/Normalizer/AppNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Management\Normalizer;
 
 use Apigee\Edge\Api\Management\Entity\AppInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -41,7 +42,7 @@ class AppNormalizer extends ObjectNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Management/Normalizer/AppNormalizer.php
+++ b/src/Api/Management/Normalizer/AppNormalizer.php
@@ -41,7 +41,7 @@ class AppNormalizer extends ObjectNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Management/Normalizer/CompanyMembershipNormalizer.php
+++ b/src/Api/Management/Normalizer/CompanyMembershipNormalizer.php
@@ -30,7 +30,7 @@ class CompanyMembershipNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalized = [
             'developer' => [],

--- a/src/Api/Management/Normalizer/CompanyMembershipNormalizer.php
+++ b/src/Api/Management/Normalizer/CompanyMembershipNormalizer.php
@@ -30,7 +30,7 @@ class CompanyMembershipNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $normalized = [
             'developer' => [],

--- a/src/Api/Management/Query/StatsQueryNormalizer.php
+++ b/src/Api/Management/Query/StatsQueryNormalizer.php
@@ -52,7 +52,7 @@ class StatsQueryNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var StatsQueryInterface $object */
         // Transform the object to JSON and back to an array to keep boolean values as boolean.

--- a/src/Api/Management/Query/StatsQueryNormalizer.php
+++ b/src/Api/Management/Query/StatsQueryNormalizer.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Api\Management\Query;
 
 use Apigee\Edge\Serializer\JsonEncoder;
+use ArrayObject;
 use DateTimeZone;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -52,7 +53,7 @@ class StatsQueryNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var StatsQueryInterface $object */
         // Transform the object to JSON and back to an array to keep boolean values as boolean.

--- a/src/Api/Monetization/Normalizer/AcceptedRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/AcceptedRatePlanNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\AcceptedRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
+use ArrayObject;
 
 class AcceptedRatePlanNormalizer extends EntityNormalizer
 {
@@ -31,7 +32,7 @@ class AcceptedRatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var AcceptedRatePlanInterface $object */
         /** @var object $normalized */

--- a/src/Api/Monetization/Normalizer/AcceptedRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/AcceptedRatePlanNormalizer.php
@@ -31,7 +31,7 @@ class AcceptedRatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var AcceptedRatePlanInterface $object */
         /** @var object $normalized */

--- a/src/Api/Monetization/Normalizer/ApiPackageNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ApiPackageNormalizer.php
@@ -47,7 +47,7 @@ class ApiPackageNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalized = (array) parent::normalize($object, $format, $context);
 

--- a/src/Api/Monetization/Normalizer/ApiPackageNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ApiPackageNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\ApiPackageInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\ApiPackageNameConverter;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -47,7 +48,7 @@ class ApiPackageNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $normalized = (array) parent::normalize($object, $format, $context);
 

--- a/src/Api/Monetization/Normalizer/CompanyPaymentTransactionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/CompanyPaymentTransactionNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\NameConverter\CompanyRatePlanNameConverter;
 use Apigee\Edge\Api\Monetization\Structure\CompanyPaymentTransaction;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -47,7 +48,7 @@ class CompanyPaymentTransactionNormalizer extends PaymentTransactionNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/CompanyPaymentTransactionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/CompanyPaymentTransactionNormalizer.php
@@ -47,7 +47,7 @@ class CompanyPaymentTransactionNormalizer extends PaymentTransactionNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/DateTimeZoneNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DateTimeZoneNormalizer.php
@@ -18,6 +18,7 @@
 
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
+use ArrayObject;
 use DateTimeZone;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -26,7 +27,7 @@ class DateTimeZoneNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         return $object->getName();
     }

--- a/src/Api/Monetization/Normalizer/DateTimeZoneNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DateTimeZoneNormalizer.php
@@ -26,7 +26,7 @@ class DateTimeZoneNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return $object->getName();
     }

--- a/src/Api/Monetization/Normalizer/DeveloperCategoryRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DeveloperCategoryRatePlanNormalizer.php
@@ -29,7 +29,7 @@ class DeveloperCategoryRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/DeveloperCategoryRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DeveloperCategoryRatePlanNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
+use ArrayObject;
 
 class DeveloperCategoryRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -29,7 +30,7 @@ class DeveloperCategoryRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/DeveloperPaymentTransactionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DeveloperPaymentTransactionNormalizer.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Structure\DeveloperPaymentTransaction;
+use ArrayObject;
 
 class DeveloperPaymentTransactionNormalizer extends PaymentTransactionNormalizer
 {
@@ -28,7 +29,7 @@ class DeveloperPaymentTransactionNormalizer extends PaymentTransactionNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/DeveloperPaymentTransactionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DeveloperPaymentTransactionNormalizer.php
@@ -28,7 +28,7 @@ class DeveloperPaymentTransactionNormalizer extends PaymentTransactionNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/EntityNormalizer.php
+++ b/src/Api/Monetization/Normalizer/EntityNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Structure\NestedObjectReferenceInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use ReflectionObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -63,7 +64,7 @@ class EntityNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType stdClass is also an object.
      * @psalm-suppress InvalidPropertyFetch.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $normalized = (array) parent::normalize($object, $format, $context);
 

--- a/src/Api/Monetization/Normalizer/EntityNormalizer.php
+++ b/src/Api/Monetization/Normalizer/EntityNormalizer.php
@@ -63,7 +63,7 @@ class EntityNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType stdClass is also an object.
      * @psalm-suppress InvalidPropertyFetch.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalized = (array) parent::normalize($object, $format, $context);
 

--- a/src/Api/Monetization/Normalizer/LegalEntityNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityNormalizer.php
@@ -22,6 +22,7 @@ use Apigee\Edge\Api\Monetization\Entity\CompanyInterface;
 use Apigee\Edge\Api\Monetization\Entity\DeveloperInterface;
 use Apigee\Edge\Api\Monetization\Entity\LegalEntityInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\LegalEntityNameConvert;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -49,7 +50,7 @@ class LegalEntityNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/LegalEntityNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityNormalizer.php
@@ -49,7 +49,7 @@ class LegalEntityNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/LegalEntityRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityRatePlanNormalizer.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
+use ArrayObject;
 
 abstract class LegalEntityRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -28,7 +29,7 @@ abstract class LegalEntityRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/LegalEntityRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityRatePlanNormalizer.php
@@ -28,7 +28,7 @@ abstract class LegalEntityRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/LegalEntityReportDefinitionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityReportDefinitionNormalizer.php
@@ -18,6 +18,8 @@
 
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
+use ArrayObject;
+
 abstract class LegalEntityReportDefinitionNormalizer extends ReportDefinitionNormalizer
 {
     /**
@@ -26,7 +28,7 @@ abstract class LegalEntityReportDefinitionNormalizer extends ReportDefinitionNor
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/LegalEntityReportDefinitionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityReportDefinitionNormalizer.php
@@ -26,7 +26,7 @@ abstract class LegalEntityReportDefinitionNormalizer extends ReportDefinitionNor
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/RatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/RatePlanNormalizer.php
@@ -51,7 +51,7 @@ abstract class RatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/RatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/RatePlanNormalizer.php
@@ -22,6 +22,7 @@ use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\RatePlanNameConverter;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Exception\UninitializedPropertyException;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -51,7 +52,7 @@ abstract class RatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/RatePlanNormalizerFactory.php
+++ b/src/Api/Monetization/Normalizer/RatePlanNormalizerFactory.php
@@ -53,7 +53,7 @@ class RatePlanNormalizerFactory implements NormalizerInterface, SerializerAwareI
      * @psalm-suppress InvalidNullableReturnType - There are going to be at
      * least one normalizer always that can normalize data here.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         foreach ($this->normalizers as $normalizer) {
             // Return the result from the first denormalizer that can

--- a/src/Api/Monetization/Normalizer/RatePlanNormalizerFactory.php
+++ b/src/Api/Monetization/Normalizer/RatePlanNormalizerFactory.php
@@ -18,6 +18,7 @@
 
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
@@ -53,7 +54,7 @@ class RatePlanNormalizerFactory implements NormalizerInterface, SerializerAwareI
      * @psalm-suppress InvalidNullableReturnType - There are going to be at
      * least one normalizer always that can normalize data here.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         foreach ($this->normalizers as $normalizer) {
             // Return the result from the first denormalizer that can

--- a/src/Api/Monetization/Normalizer/RatePlanRateNormalizer.php
+++ b/src/Api/Monetization/Normalizer/RatePlanRateNormalizer.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRate;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRateRevShare;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 
 class RatePlanRateNormalizer extends ObjectNormalizer
 {
@@ -30,7 +31,7 @@ class RatePlanRateNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/RatePlanRateNormalizer.php
+++ b/src/Api/Monetization/Normalizer/RatePlanRateNormalizer.php
@@ -30,7 +30,7 @@ class RatePlanRateNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/ReportCriteriaNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ReportCriteriaNormalizer.php
@@ -22,6 +22,7 @@ use Apigee\Edge\Api\Monetization\NameConverter\ReportCriteriaNameConverter;
 use Apigee\Edge\Api\Monetization\Structure\Reports\Criteria\AbstractCriteria;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use DateTimeZone;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -59,7 +60,7 @@ class ReportCriteriaNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/ReportCriteriaNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ReportCriteriaNormalizer.php
@@ -59,7 +59,7 @@ class ReportCriteriaNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/ReportDefinitionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ReportDefinitionNormalizer.php
@@ -50,7 +50,7 @@ class ReportDefinitionNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var ReportDefinitionInterface $object */
         /** @var object $normalized */

--- a/src/Api/Monetization/Normalizer/ReportDefinitionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ReportDefinitionNormalizer.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 use Apigee\Edge\Api\Monetization\Entity\ReportDefinitionInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\ReportDefinitionNameConverter;
 use Apigee\Edge\Api\Monetization\Utility\ReportTypeFromCriteriaHelperTrait;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -50,7 +51,7 @@ class ReportDefinitionNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var ReportDefinitionInterface $object */
         /** @var object $normalized */

--- a/src/Api/Monetization/Normalizer/StandardRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/StandardRatePlanNormalizer.php
@@ -29,7 +29,7 @@ class StandardRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/StandardRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/StandardRatePlanNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\StandardRatePlanInterface;
+use ArrayObject;
 
 class StandardRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -29,7 +30,7 @@ class StandardRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/TermsAndConditionsNormalizer.php
+++ b/src/Api/Monetization/Normalizer/TermsAndConditionsNormalizer.php
@@ -22,6 +22,7 @@ use Apigee\Edge\Api\Monetization\Entity\TermsAndConditionsInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\TermsAndConditionsNameConverter;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Exception\UninitializedPropertyException;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -51,7 +52,7 @@ class TermsAndConditionsNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/TermsAndConditionsNormalizer.php
+++ b/src/Api/Monetization/Normalizer/TermsAndConditionsNormalizer.php
@@ -51,7 +51,7 @@ class TermsAndConditionsNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -63,7 +63,7 @@ interface ClientInterface extends HttpClient
      */
     public const APIGEE_ON_GCP_ENDPOINT = 'https://apigee.googleapis.com/v1';
 
-    public const VERSION = '3.0.7';
+    public const VERSION = '3.0.8';
 
     /**
      * Allows access to the last request, response and exception.

--- a/src/Normalizer/CredentialProductNormalizer.php
+++ b/src/Normalizer/CredentialProductNormalizer.php
@@ -33,7 +33,7 @@ class CredentialProductNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /* @var \Apigee\Edge\Structure\CredentialProductInterface $object */
         $asObject = [

--- a/src/Normalizer/CredentialProductNormalizer.php
+++ b/src/Normalizer/CredentialProductNormalizer.php
@@ -33,7 +33,7 @@ class CredentialProductNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /* @var \Apigee\Edge\Structure\CredentialProductInterface $object */
         $asObject = [

--- a/src/Normalizer/EdgeDateNormalizer.php
+++ b/src/Normalizer/EdgeDateNormalizer.php
@@ -18,6 +18,7 @@
 
 namespace Apigee\Edge\Normalizer;
 
+use ArrayObject;
 use DateTimeInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -34,7 +35,7 @@ class EdgeDateNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /* @var \DateTimeInterface $object */
         return $object->getTimestamp() * 1000;

--- a/src/Normalizer/EdgeDateNormalizer.php
+++ b/src/Normalizer/EdgeDateNormalizer.php
@@ -34,7 +34,7 @@ class EdgeDateNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /* @var \DateTimeInterface $object */
         return $object->getTimestamp() * 1000;

--- a/src/Normalizer/KeyValueMapNormalizer.php
+++ b/src/Normalizer/KeyValueMapNormalizer.php
@@ -29,7 +29,7 @@ class KeyValueMapNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $return = [];
         foreach ($object->values() as $key => $value) {

--- a/src/Normalizer/KeyValueMapNormalizer.php
+++ b/src/Normalizer/KeyValueMapNormalizer.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Normalizer;
 
 use Apigee\Edge\Structure\KeyValueMapInterface;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -29,7 +30,7 @@ class KeyValueMapNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $return = [];
         foreach ($object->values() as $key => $value) {

--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -94,7 +94,7 @@ class ObjectNormalizer implements NormalizerInterface, SerializerAwareInterface
      * @psalm-suppress PossiblyInvalidArgument First argument of array_filter is always an array.
      * @psalm-suppress PossiblyNullArgument First argument of array_filter is always an array.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $asArray = $this->objectNormalizer->normalize($object, $this->format, $context);
         // Exclude null values from the output, even if PATCH is not supported on Apigee Edge

--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -94,7 +94,7 @@ class ObjectNormalizer implements NormalizerInterface, SerializerAwareInterface
      * @psalm-suppress PossiblyInvalidArgument First argument of array_filter is always an array.
      * @psalm-suppress PossiblyNullArgument First argument of array_filter is always an array.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $asArray = $this->objectNormalizer->normalize($object, $this->format, $context);
         // Exclude null values from the output, even if PATCH is not supported on Apigee Edge

--- a/src/Normalizer/PropertiesPropertyNormalizer.php
+++ b/src/Normalizer/PropertiesPropertyNormalizer.php
@@ -34,7 +34,7 @@ class PropertiesPropertyNormalizer extends KeyValueMapNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $return = [
             'property' => parent::normalize($object, $format, $context),

--- a/src/Normalizer/PropertiesPropertyNormalizer.php
+++ b/src/Normalizer/PropertiesPropertyNormalizer.php
@@ -34,7 +34,7 @@ class PropertiesPropertyNormalizer extends KeyValueMapNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $return = [
             'property' => parent::normalize($object, $format, $context),

--- a/src/Serializer/EntitySerializer.php
+++ b/src/Serializer/EntitySerializer.php
@@ -90,7 +90,7 @@ class EntitySerializer implements EntitySerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return $this->serializer->normalize($object, $format, $context);
     }

--- a/src/Serializer/EntitySerializer.php
+++ b/src/Serializer/EntitySerializer.php
@@ -25,6 +25,7 @@ use Apigee\Edge\Entity\EntityInterface;
 use Apigee\Edge\Normalizer\EdgeDateNormalizer;
 use Apigee\Edge\Normalizer\KeyValueMapNormalizer;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionMethod;
 use ReflectionObject;
@@ -90,7 +91,7 @@ class EntitySerializer implements EntitySerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         return $this->serializer->normalize($object, $format, $context);
     }


### PR DESCRIPTION
Fixes #383 