### PR TITLE
Fixes issue of Method normalize with return type '' is different to return type 'ArrayObject|array<array-key, mixed>|null|scalar' of inherited method NormalizerInterface::normalize

### DIFF
--- a/src/Api/ApigeeX/Normalizer/AcceptedRatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AcceptedRatePlanNormalizer.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\ApigeeX\Entity\AcceptedRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
+use ArrayObject;
 
 class AcceptedRatePlanNormalizer extends EntityNormalizer
 {
@@ -32,7 +33,7 @@ class AcceptedRatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var AcceptedRatePlanInterface $object */
         /** @var object $normalized */

--- a/src/Api/ApigeeX/Normalizer/AcceptedRatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AcceptedRatePlanNormalizer.php
@@ -21,7 +21,6 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\ApigeeX\Entity\AcceptedRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
-use ArrayObject;
 
 class AcceptedRatePlanNormalizer extends EntityNormalizer
 {
@@ -33,7 +32,7 @@ class AcceptedRatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var AcceptedRatePlanInterface $object */
         /** @var object $normalized */
@@ -45,7 +44,7 @@ class AcceptedRatePlanNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof AcceptedRatePlanInterface;
     }

--- a/src/Api/ApigeeX/Normalizer/ApiProductNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/ApiProductNormalizer.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\ApigeeX\Entity\ApiProductInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\ApiPackageNameConverter;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -48,7 +49,7 @@ class ApiProductNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $normalized = parent::normalize($object, $format, $context);
 

--- a/src/Api/ApigeeX/Normalizer/ApiProductNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/ApiProductNormalizer.php
@@ -21,7 +21,6 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\ApigeeX\Entity\ApiProductInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\ApiPackageNameConverter;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
-use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -49,7 +48,7 @@ class ApiProductNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalized = parent::normalize($object, $format, $context);
 
@@ -59,7 +58,7 @@ class ApiProductNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ApiProductInterface;
     }

--- a/src/Api/ApigeeX/Normalizer/AppGroupMembershipNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AppGroupMembershipNormalizer.php
@@ -19,7 +19,6 @@
 namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\ApigeeX\Structure\AppGroupMembership;
-use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class AppGroupMembershipNormalizer implements NormalizerInterface
@@ -30,7 +29,7 @@ class AppGroupMembershipNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalized = [];
 
@@ -45,7 +44,7 @@ class AppGroupMembershipNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof AppGroupMembership;
     }

--- a/src/Api/ApigeeX/Normalizer/AppGroupMembershipNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AppGroupMembershipNormalizer.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\ApigeeX\Structure\AppGroupMembership;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class AppGroupMembershipNormalizer implements NormalizerInterface
@@ -29,7 +30,7 @@ class AppGroupMembershipNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $normalized = [];
 

--- a/src/Api/ApigeeX/Normalizer/AppGroupMembershipNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AppGroupMembershipNormalizer.php
@@ -48,4 +48,14 @@ class AppGroupMembershipNormalizer implements NormalizerInterface
     {
         return $data instanceof AppGroupMembership;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            AppGroupMembership::class => true,
+        ];
+    }
 }

--- a/src/Api/ApigeeX/Normalizer/AppNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AppNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\Management\Entity\AppInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -41,7 +42,7 @@ class AppNormalizer extends ObjectNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/AppNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/AppNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\Management\Entity\AppInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
-use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -31,7 +30,7 @@ class AppNormalizer extends ObjectNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof AppInterface;
     }
@@ -42,7 +41,7 @@ class AppNormalizer extends ObjectNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/BillingTypeNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/BillingTypeNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\ApigeeX\Entity\BillingTypeInterface;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
-use ArrayObject;
 
 class BillingTypeNormalizer extends EntityNormalizer
 {
@@ -30,7 +29,7 @@ class BillingTypeNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var BillingTypeInterface $object */
         /** @var object $normalized */
@@ -42,7 +41,7 @@ class BillingTypeNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof BillingTypeInterface;
     }

--- a/src/Api/ApigeeX/Normalizer/BillingTypeNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/BillingTypeNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\ApigeeX\Entity\BillingTypeInterface;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
+use ArrayObject;
 
 class BillingTypeNormalizer extends EntityNormalizer
 {
@@ -29,7 +30,7 @@ class BillingTypeNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var BillingTypeInterface $object */
         /** @var object $normalized */

--- a/src/Api/ApigeeX/Normalizer/PrepaidBalanceNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/PrepaidBalanceNormalizer.php
@@ -45,7 +45,7 @@ class PrepaidBalanceNormalizer extends EntityNormalizer
     /**
      * {@inheritDoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof PrepaidBalanceInterface;
     }

--- a/src/Api/ApigeeX/Normalizer/RatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanNormalizer.php
@@ -23,7 +23,6 @@ use Apigee\Edge\Api\ApigeeX\NameConverter\RatePlanNameConverter;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Exception\UninitializedPropertyException;
-use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -53,7 +52,7 @@ abstract class RatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -71,7 +70,7 @@ abstract class RatePlanNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof RatePlanInterface;
     }

--- a/src/Api/ApigeeX/Normalizer/RatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanNormalizer.php
@@ -23,6 +23,7 @@ use Apigee\Edge\Api\ApigeeX\NameConverter\RatePlanNameConverter;
 use Apigee\Edge\Api\Monetization\Normalizer\EntityNormalizer;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Exception\UninitializedPropertyException;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -52,7 +53,7 @@ abstract class RatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/RatePlanNormalizerFactory.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanNormalizerFactory.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\Monetization\Normalizer\CompanyRatePlanNormalizer;
 use Apigee\Edge\Api\Monetization\Normalizer\DeveloperCategoryRatePlanNormalizer;
 use Apigee\Edge\Api\Monetization\Normalizer\DeveloperRatePlanNormalizer;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
@@ -56,7 +57,7 @@ class RatePlanNormalizerFactory implements NormalizerInterface, SerializerAwareI
      * @psalm-suppress InvalidNullableReturnType - There are going to be at
      * least one normalizer always that can normalize data here.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         foreach ($this->normalizers as $normalizer) {
             // Return the result from the first denormalizer that can

--- a/src/Api/ApigeeX/Normalizer/RatePlanNormalizerFactory.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanNormalizerFactory.php
@@ -21,7 +21,6 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\Monetization\Normalizer\CompanyRatePlanNormalizer;
 use Apigee\Edge\Api\Monetization\Normalizer\DeveloperCategoryRatePlanNormalizer;
 use Apigee\Edge\Api\Monetization\Normalizer\DeveloperRatePlanNormalizer;
-use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
@@ -57,7 +56,7 @@ class RatePlanNormalizerFactory implements NormalizerInterface, SerializerAwareI
      * @psalm-suppress InvalidNullableReturnType - There are going to be at
      * least one normalizer always that can normalize data here.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         foreach ($this->normalizers as $normalizer) {
             // Return the result from the first denormalizer that can
@@ -71,7 +70,7 @@ class RatePlanNormalizerFactory implements NormalizerInterface, SerializerAwareI
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         foreach ($this->normalizers as $denormalizer) {
             if ($denormalizer->supportsNormalization($data, $format)) {

--- a/src/Api/ApigeeX/Normalizer/RatePlanRateNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanRateNormalizer.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRate;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRateRevShare;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 
 class RatePlanRateNormalizer extends ObjectNormalizer
 {
@@ -30,7 +31,7 @@ class RatePlanRateNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/ApigeeX/Normalizer/RatePlanRateNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/RatePlanRateNormalizer.php
@@ -21,7 +21,6 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRate;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRateRevShare;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
-use ArrayObject;
 
 class RatePlanRateNormalizer extends ObjectNormalizer
 {
@@ -31,7 +30,7 @@ class RatePlanRateNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -47,7 +46,7 @@ class RatePlanRateNormalizer extends ObjectNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof RatePlanRate;
     }

--- a/src/Api/ApigeeX/Normalizer/StandardRatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/StandardRatePlanNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\ApigeeX\Entity\RatePlanInterface;
 use Apigee\Edge\Api\ApigeeX\Entity\StandardRatePlanInterface;
-use ArrayObject;
 
 class StandardRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -30,7 +29,7 @@ class StandardRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -42,7 +41,7 @@ class StandardRatePlanNormalizer extends RatePlanNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof StandardRatePlanInterface;
     }

--- a/src/Api/ApigeeX/Normalizer/StandardRatePlanNormalizer.php
+++ b/src/Api/ApigeeX/Normalizer/StandardRatePlanNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\ApigeeX\Normalizer;
 
 use Apigee\Edge\Api\ApigeeX\Entity\RatePlanInterface;
 use Apigee\Edge\Api\ApigeeX\Entity\StandardRatePlanInterface;
+use ArrayObject;
 
 class StandardRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -29,7 +30,7 @@ class StandardRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Management/Normalizer/AppCredentialNormalizer.php
+++ b/src/Api/Management/Normalizer/AppCredentialNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\Management\Normalizer;
 
 use Apigee\Edge\Api\Management\Entity\AppCredentialInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
-use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -31,7 +30,7 @@ class AppCredentialNormalizer extends ObjectNormalizer implements NormalizerInte
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof AppCredentialInterface;
     }
@@ -42,7 +41,7 @@ class AppCredentialNormalizer extends ObjectNormalizer implements NormalizerInte
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Management/Normalizer/AppCredentialNormalizer.php
+++ b/src/Api/Management/Normalizer/AppCredentialNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Management\Normalizer;
 
 use Apigee\Edge\Api\Management\Entity\AppCredentialInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -41,7 +42,7 @@ class AppCredentialNormalizer extends ObjectNormalizer implements NormalizerInte
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Management/Normalizer/AppNormalizer.php
+++ b/src/Api/Management/Normalizer/AppNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\Management\Normalizer;
 
 use Apigee\Edge\Api\Management\Entity\AppInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
-use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -31,7 +30,7 @@ class AppNormalizer extends ObjectNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof AppInterface;
     }
@@ -42,7 +41,7 @@ class AppNormalizer extends ObjectNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Management/Normalizer/AppNormalizer.php
+++ b/src/Api/Management/Normalizer/AppNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Management\Normalizer;
 
 use Apigee\Edge\Api\Management\Entity\AppInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -41,7 +42,7 @@ class AppNormalizer extends ObjectNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Management/Normalizer/CompanyMembershipNormalizer.php
+++ b/src/Api/Management/Normalizer/CompanyMembershipNormalizer.php
@@ -19,7 +19,6 @@
 namespace Apigee\Edge\Api\Management\Normalizer;
 
 use Apigee\Edge\Api\Management\Structure\CompanyMembership;
-use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class CompanyMembershipNormalizer implements NormalizerInterface
@@ -30,7 +29,7 @@ class CompanyMembershipNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalized = [
             'developer' => [],
@@ -48,7 +47,7 @@ class CompanyMembershipNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CompanyMembership;
     }

--- a/src/Api/Management/Normalizer/CompanyMembershipNormalizer.php
+++ b/src/Api/Management/Normalizer/CompanyMembershipNormalizer.php
@@ -41,7 +41,7 @@ class CompanyMembershipNormalizer implements NormalizerInterface
 
         // convert to ArrayObject as symfony normalizer throws error for std object.
         // set ARRAY_AS_PROPS flag as we need entries to be accessed as properties.
-        return new ArrayObject($normalized, ArrayObject::ARRAY_AS_PROPS);
+        return new \ArrayObject($normalized, \ArrayObject::ARRAY_AS_PROPS);
     }
 
     /**

--- a/src/Api/Management/Normalizer/CompanyMembershipNormalizer.php
+++ b/src/Api/Management/Normalizer/CompanyMembershipNormalizer.php
@@ -30,7 +30,7 @@ class CompanyMembershipNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $normalized = [
             'developer' => [],

--- a/src/Api/Management/Query/StatsQueryNormalizer.php
+++ b/src/Api/Management/Query/StatsQueryNormalizer.php
@@ -19,7 +19,6 @@
 namespace Apigee\Edge\Api\Management\Query;
 
 use Apigee\Edge\Serializer\JsonEncoder;
-use ArrayObject;
 use DateTimeZone;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -53,7 +52,7 @@ class StatsQueryNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var StatsQueryInterface $object */
         // Transform the object to JSON and back to an array to keep boolean values as boolean.
@@ -93,7 +92,7 @@ class StatsQueryNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof StatsQuery;
     }

--- a/src/Api/Management/Query/StatsQueryNormalizer.php
+++ b/src/Api/Management/Query/StatsQueryNormalizer.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Api\Management\Query;
 
 use Apigee\Edge\Serializer\JsonEncoder;
+use ArrayObject;
 use DateTimeZone;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -52,7 +53,7 @@ class StatsQueryNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var StatsQueryInterface $object */
         // Transform the object to JSON and back to an array to keep boolean values as boolean.

--- a/src/Api/Monetization/Normalizer/AcceptedRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/AcceptedRatePlanNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\AcceptedRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
+use ArrayObject;
 
 class AcceptedRatePlanNormalizer extends EntityNormalizer
 {
@@ -31,7 +32,7 @@ class AcceptedRatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var AcceptedRatePlanInterface $object */
         /** @var object $normalized */

--- a/src/Api/Monetization/Normalizer/AcceptedRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/AcceptedRatePlanNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\AcceptedRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
-use ArrayObject;
 
 class AcceptedRatePlanNormalizer extends EntityNormalizer
 {
@@ -32,7 +31,7 @@ class AcceptedRatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var AcceptedRatePlanInterface $object */
         /** @var object $normalized */
@@ -45,7 +44,7 @@ class AcceptedRatePlanNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof AcceptedRatePlanInterface;
     }

--- a/src/Api/Monetization/Normalizer/AddressNormalizer.php
+++ b/src/Api/Monetization/Normalizer/AddressNormalizer.php
@@ -45,7 +45,7 @@ class AddressNormalizer extends ObjectNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof Address;
     }

--- a/src/Api/Monetization/Normalizer/ApiPackageNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ApiPackageNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\ApiPackageInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\ApiPackageNameConverter;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -47,7 +48,7 @@ class ApiPackageNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $normalized = (array) parent::normalize($object, $format, $context);
 

--- a/src/Api/Monetization/Normalizer/ApiPackageNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ApiPackageNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\ApiPackageInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\ApiPackageNameConverter;
-use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -48,7 +47,7 @@ class ApiPackageNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalized = (array) parent::normalize($object, $format, $context);
 
@@ -64,7 +63,7 @@ class ApiPackageNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ApiPackageInterface;
     }

--- a/src/Api/Monetization/Normalizer/BalanceNormalizer.php
+++ b/src/Api/Monetization/Normalizer/BalanceNormalizer.php
@@ -44,7 +44,7 @@ class BalanceNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof BalanceInterface;
     }

--- a/src/Api/Monetization/Normalizer/CompanyAcceptedRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/CompanyAcceptedRatePlanNormalizer.php
@@ -44,7 +44,7 @@ class CompanyAcceptedRatePlanNormalizer extends AcceptedRatePlanNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CompanyAcceptedRatePlanInterface;
     }

--- a/src/Api/Monetization/Normalizer/CompanyPaymentTransactionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/CompanyPaymentTransactionNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\NameConverter\CompanyRatePlanNameConverter;
 use Apigee\Edge\Api\Monetization\Structure\CompanyPaymentTransaction;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -47,7 +48,7 @@ class CompanyPaymentTransactionNormalizer extends PaymentTransactionNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/CompanyPaymentTransactionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/CompanyPaymentTransactionNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\NameConverter\CompanyRatePlanNameConverter;
 use Apigee\Edge\Api\Monetization\Structure\CompanyPaymentTransaction;
-use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -48,7 +47,7 @@ class CompanyPaymentTransactionNormalizer extends PaymentTransactionNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -60,7 +59,7 @@ class CompanyPaymentTransactionNormalizer extends PaymentTransactionNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CompanyPaymentTransaction;
     }

--- a/src/Api/Monetization/Normalizer/CompanyRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/CompanyRatePlanNormalizer.php
@@ -44,7 +44,7 @@ class CompanyRatePlanNormalizer extends LegalEntityRatePlanNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CompanyRatePlanInterface;
     }

--- a/src/Api/Monetization/Normalizer/CompanyReportDefinitionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/CompanyReportDefinitionNormalizer.php
@@ -44,7 +44,7 @@ class CompanyReportDefinitionNormalizer extends LegalEntityReportDefinitionNorma
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CompanyReportDefinitionInterface;
     }

--- a/src/Api/Monetization/Normalizer/DateTimeZoneNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DateTimeZoneNormalizer.php
@@ -18,7 +18,6 @@
 
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
-use ArrayObject;
 use DateTimeZone;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -27,7 +26,7 @@ class DateTimeZoneNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return $object->getName();
     }
@@ -35,7 +34,7 @@ class DateTimeZoneNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof DateTimeZone;
     }

--- a/src/Api/Monetization/Normalizer/DateTimeZoneNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DateTimeZoneNormalizer.php
@@ -18,6 +18,7 @@
 
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
+use ArrayObject;
 use DateTimeZone;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -26,7 +27,7 @@ class DateTimeZoneNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         return $object->getName();
     }

--- a/src/Api/Monetization/Normalizer/DeveloperCategoryRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DeveloperCategoryRatePlanNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
-use ArrayObject;
 
 class DeveloperCategoryRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -30,7 +29,7 @@ class DeveloperCategoryRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -42,7 +41,7 @@ class DeveloperCategoryRatePlanNormalizer extends RatePlanNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof DeveloperCategoryRatePlanInterface;
     }

--- a/src/Api/Monetization/Normalizer/DeveloperCategoryRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DeveloperCategoryRatePlanNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\DeveloperCategoryRatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
+use ArrayObject;
 
 class DeveloperCategoryRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -29,7 +30,7 @@ class DeveloperCategoryRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/DeveloperPaymentTransactionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DeveloperPaymentTransactionNormalizer.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Structure\DeveloperPaymentTransaction;
+use ArrayObject;
 
 class DeveloperPaymentTransactionNormalizer extends PaymentTransactionNormalizer
 {
@@ -28,7 +29,7 @@ class DeveloperPaymentTransactionNormalizer extends PaymentTransactionNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/DeveloperPaymentTransactionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DeveloperPaymentTransactionNormalizer.php
@@ -19,7 +19,6 @@
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Structure\DeveloperPaymentTransaction;
-use ArrayObject;
 
 class DeveloperPaymentTransactionNormalizer extends PaymentTransactionNormalizer
 {
@@ -29,7 +28,7 @@ class DeveloperPaymentTransactionNormalizer extends PaymentTransactionNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -41,7 +40,7 @@ class DeveloperPaymentTransactionNormalizer extends PaymentTransactionNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof DeveloperPaymentTransaction;
     }

--- a/src/Api/Monetization/Normalizer/DeveloperRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DeveloperRatePlanNormalizer.php
@@ -25,7 +25,7 @@ class DeveloperRatePlanNormalizer extends LegalEntityRatePlanNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof DeveloperRatePlanInterface;
     }

--- a/src/Api/Monetization/Normalizer/DeveloperReportDefinitionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/DeveloperReportDefinitionNormalizer.php
@@ -25,7 +25,7 @@ class DeveloperReportDefinitionNormalizer extends LegalEntityReportDefinitionNor
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof DeveloperReportDefinitionInterface;
     }

--- a/src/Api/Monetization/Normalizer/EntityNormalizer.php
+++ b/src/Api/Monetization/Normalizer/EntityNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Structure\NestedObjectReferenceInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use ReflectionObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -63,7 +64,7 @@ class EntityNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType stdClass is also an object.
      * @psalm-suppress InvalidPropertyFetch.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $normalized = (array) parent::normalize($object, $format, $context);
 

--- a/src/Api/Monetization/Normalizer/EntityNormalizer.php
+++ b/src/Api/Monetization/Normalizer/EntityNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Structure\NestedObjectReferenceInterface;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
-use ArrayObject;
 use ReflectionObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -64,7 +63,7 @@ class EntityNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType stdClass is also an object.
      * @psalm-suppress InvalidPropertyFetch.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $normalized = (array) parent::normalize($object, $format, $context);
 

--- a/src/Api/Monetization/Normalizer/LegalEntityNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityNormalizer.php
@@ -22,6 +22,7 @@ use Apigee\Edge\Api\Monetization\Entity\CompanyInterface;
 use Apigee\Edge\Api\Monetization\Entity\DeveloperInterface;
 use Apigee\Edge\Api\Monetization\Entity\LegalEntityInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\LegalEntityNameConvert;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -49,7 +50,7 @@ class LegalEntityNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/LegalEntityNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityNormalizer.php
@@ -22,7 +22,6 @@ use Apigee\Edge\Api\Monetization\Entity\CompanyInterface;
 use Apigee\Edge\Api\Monetization\Entity\DeveloperInterface;
 use Apigee\Edge\Api\Monetization\Entity\LegalEntityInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\LegalEntityNameConvert;
-use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -50,7 +49,7 @@ class LegalEntityNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -67,7 +66,7 @@ class LegalEntityNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof LegalEntityInterface;
     }

--- a/src/Api/Monetization/Normalizer/LegalEntityRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityRatePlanNormalizer.php
@@ -19,7 +19,6 @@
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
-use ArrayObject;
 
 abstract class LegalEntityRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -29,7 +28,7 @@ abstract class LegalEntityRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/LegalEntityRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityRatePlanNormalizer.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
+use ArrayObject;
 
 abstract class LegalEntityRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -28,7 +29,7 @@ abstract class LegalEntityRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/LegalEntityReportDefinitionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityReportDefinitionNormalizer.php
@@ -18,6 +18,8 @@
 
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
+use ArrayObject;
+
 abstract class LegalEntityReportDefinitionNormalizer extends ReportDefinitionNormalizer
 {
     /**
@@ -26,7 +28,7 @@ abstract class LegalEntityReportDefinitionNormalizer extends ReportDefinitionNor
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/LegalEntityReportDefinitionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/LegalEntityReportDefinitionNormalizer.php
@@ -18,7 +18,6 @@
 
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
-use ArrayObject;
 
 abstract class LegalEntityReportDefinitionNormalizer extends ReportDefinitionNormalizer
 {
@@ -28,7 +27,7 @@ abstract class LegalEntityReportDefinitionNormalizer extends ReportDefinitionNor
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/OrganizationProfileNormalizer.php
+++ b/src/Api/Monetization/Normalizer/OrganizationProfileNormalizer.php
@@ -44,7 +44,7 @@ class OrganizationProfileNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof OrganizationProfileInterface;
     }

--- a/src/Api/Monetization/Normalizer/PaymentTransactionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/PaymentTransactionNormalizer.php
@@ -45,7 +45,7 @@ abstract class PaymentTransactionNormalizer extends ObjectNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof PaymentTransaction;
     }

--- a/src/Api/Monetization/Normalizer/PrepaidBalanceNormalizer.php
+++ b/src/Api/Monetization/Normalizer/PrepaidBalanceNormalizer.php
@@ -44,7 +44,7 @@ class PrepaidBalanceNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof PrepaidBalanceInterface;
     }

--- a/src/Api/Monetization/Normalizer/RatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/RatePlanNormalizer.php
@@ -22,6 +22,7 @@ use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\RatePlanNameConverter;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Exception\UninitializedPropertyException;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -51,7 +52,7 @@ abstract class RatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/RatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/RatePlanNormalizer.php
@@ -22,7 +22,6 @@ use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\RatePlanNameConverter;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Exception\UninitializedPropertyException;
-use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -52,7 +51,7 @@ abstract class RatePlanNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -76,7 +75,7 @@ abstract class RatePlanNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof RatePlanInterface;
     }

--- a/src/Api/Monetization/Normalizer/RatePlanNormalizerFactory.php
+++ b/src/Api/Monetization/Normalizer/RatePlanNormalizerFactory.php
@@ -18,6 +18,7 @@
 
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
@@ -53,7 +54,7 @@ class RatePlanNormalizerFactory implements NormalizerInterface, SerializerAwareI
      * @psalm-suppress InvalidNullableReturnType - There are going to be at
      * least one normalizer always that can normalize data here.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         foreach ($this->normalizers as $normalizer) {
             // Return the result from the first denormalizer that can

--- a/src/Api/Monetization/Normalizer/RatePlanNormalizerFactory.php
+++ b/src/Api/Monetization/Normalizer/RatePlanNormalizerFactory.php
@@ -18,7 +18,6 @@
 
 namespace Apigee\Edge\Api\Monetization\Normalizer;
 
-use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
@@ -54,7 +53,7 @@ class RatePlanNormalizerFactory implements NormalizerInterface, SerializerAwareI
      * @psalm-suppress InvalidNullableReturnType - There are going to be at
      * least one normalizer always that can normalize data here.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         foreach ($this->normalizers as $normalizer) {
             // Return the result from the first denormalizer that can
@@ -68,7 +67,7 @@ class RatePlanNormalizerFactory implements NormalizerInterface, SerializerAwareI
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         foreach ($this->normalizers as $denormalizer) {
             if ($denormalizer->supportsNormalization($data, $format)) {

--- a/src/Api/Monetization/Normalizer/RatePlanRateNormalizer.php
+++ b/src/Api/Monetization/Normalizer/RatePlanRateNormalizer.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRate;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRateRevShare;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 
 class RatePlanRateNormalizer extends ObjectNormalizer
 {
@@ -30,7 +31,7 @@ class RatePlanRateNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/RatePlanRateNormalizer.php
+++ b/src/Api/Monetization/Normalizer/RatePlanRateNormalizer.php
@@ -21,7 +21,6 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRate;
 use Apigee\Edge\Api\Monetization\Structure\RatePlanRateRevShare;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
-use ArrayObject;
 
 class RatePlanRateNormalizer extends ObjectNormalizer
 {
@@ -31,7 +30,7 @@ class RatePlanRateNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -47,7 +46,7 @@ class RatePlanRateNormalizer extends ObjectNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof RatePlanRate;
     }

--- a/src/Api/Monetization/Normalizer/ReportCriteriaNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ReportCriteriaNormalizer.php
@@ -22,6 +22,7 @@ use Apigee\Edge\Api\Monetization\NameConverter\ReportCriteriaNameConverter;
 use Apigee\Edge\Api\Monetization\Structure\Reports\Criteria\AbstractCriteria;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use DateTimeZone;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -59,7 +60,7 @@ class ReportCriteriaNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/ReportCriteriaNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ReportCriteriaNormalizer.php
@@ -22,7 +22,6 @@ use Apigee\Edge\Api\Monetization\NameConverter\ReportCriteriaNameConverter;
 use Apigee\Edge\Api\Monetization\Structure\Reports\Criteria\AbstractCriteria;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
-use ArrayObject;
 use DateTimeZone;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -60,7 +59,7 @@ class ReportCriteriaNormalizer extends ObjectNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -96,7 +95,7 @@ class ReportCriteriaNormalizer extends ObjectNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof AbstractCriteria;
     }

--- a/src/Api/Monetization/Normalizer/ReportDefinitionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ReportDefinitionNormalizer.php
@@ -21,6 +21,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 use Apigee\Edge\Api\Monetization\Entity\ReportDefinitionInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\ReportDefinitionNameConverter;
 use Apigee\Edge\Api\Monetization\Utility\ReportTypeFromCriteriaHelperTrait;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -50,7 +51,7 @@ class ReportDefinitionNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var ReportDefinitionInterface $object */
         /** @var object $normalized */

--- a/src/Api/Monetization/Normalizer/ReportDefinitionNormalizer.php
+++ b/src/Api/Monetization/Normalizer/ReportDefinitionNormalizer.php
@@ -21,7 +21,6 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 use Apigee\Edge\Api\Monetization\Entity\ReportDefinitionInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\ReportDefinitionNameConverter;
 use Apigee\Edge\Api\Monetization\Utility\ReportTypeFromCriteriaHelperTrait;
-use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -51,7 +50,7 @@ class ReportDefinitionNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var ReportDefinitionInterface $object */
         /** @var object $normalized */
@@ -68,7 +67,7 @@ class ReportDefinitionNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ReportDefinitionInterface;
     }

--- a/src/Api/Monetization/Normalizer/StandardRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/StandardRatePlanNormalizer.php
@@ -20,6 +20,7 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\StandardRatePlanInterface;
+use ArrayObject;
 
 class StandardRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -29,7 +30,7 @@ class StandardRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/StandardRatePlanNormalizer.php
+++ b/src/Api/Monetization/Normalizer/StandardRatePlanNormalizer.php
@@ -20,7 +20,6 @@ namespace Apigee\Edge\Api\Monetization\Normalizer;
 
 use Apigee\Edge\Api\Monetization\Entity\RatePlanInterface;
 use Apigee\Edge\Api\Monetization\Entity\StandardRatePlanInterface;
-use ArrayObject;
 
 class StandardRatePlanNormalizer extends RatePlanNormalizer
 {
@@ -30,7 +29,7 @@ class StandardRatePlanNormalizer extends RatePlanNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -42,7 +41,7 @@ class StandardRatePlanNormalizer extends RatePlanNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof StandardRatePlanInterface;
     }

--- a/src/Api/Monetization/Normalizer/SupportedCurrencyNormalizer.php
+++ b/src/Api/Monetization/Normalizer/SupportedCurrencyNormalizer.php
@@ -44,7 +44,7 @@ class SupportedCurrencyNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof SupportedCurrencyInterface;
     }

--- a/src/Api/Monetization/Normalizer/TermsAndConditionsNormalizer.php
+++ b/src/Api/Monetization/Normalizer/TermsAndConditionsNormalizer.php
@@ -22,6 +22,7 @@ use Apigee\Edge\Api\Monetization\Entity\TermsAndConditionsInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\TermsAndConditionsNameConverter;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Exception\UninitializedPropertyException;
+use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -51,7 +52,7 @@ class TermsAndConditionsNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);

--- a/src/Api/Monetization/Normalizer/TermsAndConditionsNormalizer.php
+++ b/src/Api/Monetization/Normalizer/TermsAndConditionsNormalizer.php
@@ -22,7 +22,6 @@ use Apigee\Edge\Api\Monetization\Entity\TermsAndConditionsInterface;
 use Apigee\Edge\Api\Monetization\NameConverter\TermsAndConditionsNameConverter;
 use Apigee\Edge\Api\Monetization\Utility\TimezoneFixerHelperTrait;
 use Apigee\Edge\Exception\UninitializedPropertyException;
-use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -52,7 +51,7 @@ class TermsAndConditionsNormalizer extends EntityNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /** @var object $normalized */
         $normalized = parent::normalize($object, $format, $context);
@@ -73,7 +72,7 @@ class TermsAndConditionsNormalizer extends EntityNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof TermsAndConditionsInterface;
     }

--- a/src/Normalizer/CredentialProductNormalizer.php
+++ b/src/Normalizer/CredentialProductNormalizer.php
@@ -42,7 +42,7 @@ class CredentialProductNormalizer implements NormalizerInterface
 
         // Need to convert to ArrayObject as symfony normalizer throws error for std object.
         // Need to set ARRAY_AS_PROPS flag as we need Entries to be accessed as properties.
-        return new ArrayObject($asObject, ArrayObject::ARRAY_AS_PROPS);
+        return new \ArrayObject($asObject, \ArrayObject::ARRAY_AS_PROPS);
     }
 
     /**

--- a/src/Normalizer/CredentialProductNormalizer.php
+++ b/src/Normalizer/CredentialProductNormalizer.php
@@ -33,7 +33,7 @@ class CredentialProductNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /* @var \Apigee\Edge\Structure\CredentialProductInterface $object */
         $asObject = [

--- a/src/Normalizer/CredentialProductNormalizer.php
+++ b/src/Normalizer/CredentialProductNormalizer.php
@@ -19,7 +19,6 @@
 namespace Apigee\Edge\Normalizer;
 
 use Apigee\Edge\Structure\CredentialProductInterface;
-use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -33,7 +32,7 @@ class CredentialProductNormalizer implements NormalizerInterface
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /* @var \Apigee\Edge\Structure\CredentialProductInterface $object */
         $asObject = [
@@ -49,7 +48,7 @@ class CredentialProductNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CredentialProductInterface;
     }

--- a/src/Normalizer/EdgeDateNormalizer.php
+++ b/src/Normalizer/EdgeDateNormalizer.php
@@ -18,7 +18,6 @@
 
 namespace Apigee\Edge\Normalizer;
 
-use ArrayObject;
 use DateTimeInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -27,7 +26,7 @@ class EdgeDateNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof DateTimeInterface;
     }
@@ -35,7 +34,7 @@ class EdgeDateNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         /* @var \DateTimeInterface $object */
         return $object->getTimestamp() * 1000;

--- a/src/Normalizer/EdgeDateNormalizer.php
+++ b/src/Normalizer/EdgeDateNormalizer.php
@@ -18,6 +18,7 @@
 
 namespace Apigee\Edge\Normalizer;
 
+use ArrayObject;
 use DateTimeInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -34,7 +35,7 @@ class EdgeDateNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         /* @var \DateTimeInterface $object */
         return $object->getTimestamp() * 1000;

--- a/src/Normalizer/KeyValueMapNormalizer.php
+++ b/src/Normalizer/KeyValueMapNormalizer.php
@@ -19,6 +19,7 @@
 namespace Apigee\Edge\Normalizer;
 
 use Apigee\Edge\Structure\KeyValueMapInterface;
+use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -29,7 +30,7 @@ class KeyValueMapNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $return = [];
         foreach ($object->values() as $key => $value) {

--- a/src/Normalizer/KeyValueMapNormalizer.php
+++ b/src/Normalizer/KeyValueMapNormalizer.php
@@ -19,7 +19,6 @@
 namespace Apigee\Edge\Normalizer;
 
 use Apigee\Edge\Structure\KeyValueMapInterface;
-use ArrayObject;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -30,7 +29,7 @@ class KeyValueMapNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $return = [];
         foreach ($object->values() as $key => $value) {
@@ -43,7 +42,7 @@ class KeyValueMapNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof KeyValueMapInterface;
     }

--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -19,7 +19,6 @@
 namespace Apigee\Edge\Normalizer;
 
 use Apigee\Edge\PropertyAccess\PropertyAccessorDecorator;
-use ArrayObject;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
@@ -94,7 +93,7 @@ class ObjectNormalizer implements NormalizerInterface, SerializerAwareInterface
      * @psalm-suppress PossiblyInvalidArgument First argument of array_filter is always an array.
      * @psalm-suppress PossiblyNullArgument First argument of array_filter is always an array.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $asArray = $this->objectNormalizer->normalize($object, $this->format, $context);
         // Exclude null values from the output, even if PATCH is not supported on Apigee Edge
@@ -110,7 +109,7 @@ class ObjectNormalizer implements NormalizerInterface, SerializerAwareInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         // Enforce the only supported format if format is null.
         $format = $format ?? $this->format;

--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -94,7 +94,7 @@ class ObjectNormalizer implements NormalizerInterface, SerializerAwareInterface
      * @psalm-suppress PossiblyInvalidArgument First argument of array_filter is always an array.
      * @psalm-suppress PossiblyNullArgument First argument of array_filter is always an array.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $asArray = $this->objectNormalizer->normalize($object, $this->format, $context);
         // Exclude null values from the output, even if PATCH is not supported on Apigee Edge

--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -129,10 +129,10 @@ class ObjectNormalizer implements NormalizerInterface, SerializerAwareInterface
     /**
      * {@inheritDoc}
      */
-    public function convertToArrayObject($normalized, $array_as_props = ArrayObject::ARRAY_AS_PROPS)
+    public function convertToArrayObject($normalized, $array_as_props = \ArrayObject::ARRAY_AS_PROPS)
     {
         // default set ARRAY_AS_PROPS flag as we need entries to be accessed as properties.
-        return new ArrayObject($normalized, $array_as_props);
+        return new \ArrayObject($normalized, $array_as_props);
     }
 
     /**

--- a/src/Normalizer/PropertiesPropertyNormalizer.php
+++ b/src/Normalizer/PropertiesPropertyNormalizer.php
@@ -19,7 +19,6 @@
 namespace Apigee\Edge\Normalizer;
 
 use Apigee\Edge\Structure\PropertiesProperty;
-use ArrayObject;
 
 /**
  * Class PropertiesPropertyNormalizer.
@@ -34,7 +33,7 @@ class PropertiesPropertyNormalizer extends KeyValueMapNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $return = [
             'property' => parent::normalize($object, $format, $context),
@@ -48,7 +47,7 @@ class PropertiesPropertyNormalizer extends KeyValueMapNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof PropertiesProperty;
     }

--- a/src/Normalizer/PropertiesPropertyNormalizer.php
+++ b/src/Normalizer/PropertiesPropertyNormalizer.php
@@ -41,7 +41,7 @@ class PropertiesPropertyNormalizer extends KeyValueMapNormalizer
 
         // convert to ArrayObject as symfony normalizer throws error for std object.
         // set ARRAY_AS_PROPS flag as we need entries to be accessed as properties.
-        return new ArrayObject($return, ArrayObject::ARRAY_AS_PROPS);
+        return new \ArrayObject($return, \ArrayObject::ARRAY_AS_PROPS);
     }
 
     /**

--- a/src/Normalizer/PropertiesPropertyNormalizer.php
+++ b/src/Normalizer/PropertiesPropertyNormalizer.php
@@ -34,7 +34,7 @@ class PropertiesPropertyNormalizer extends KeyValueMapNormalizer
      * @psalm-suppress InvalidReturnType Returning an object here is required
      * for creating a valid Apigee Edge request.
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         $return = [
             'property' => parent::normalize($object, $format, $context),

--- a/src/Serializer/EntitySerializer.php
+++ b/src/Serializer/EntitySerializer.php
@@ -25,6 +25,7 @@ use Apigee\Edge\Entity\EntityInterface;
 use Apigee\Edge\Normalizer\EdgeDateNormalizer;
 use Apigee\Edge\Normalizer\KeyValueMapNormalizer;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
+use ArrayObject;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionMethod;
 use ReflectionObject;
@@ -90,7 +91,7 @@ class EntitySerializer implements EntitySerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
     {
         return $this->serializer->normalize($object, $format, $context);
     }

--- a/src/Serializer/EntitySerializer.php
+++ b/src/Serializer/EntitySerializer.php
@@ -25,7 +25,6 @@ use Apigee\Edge\Entity\EntityInterface;
 use Apigee\Edge\Normalizer\EdgeDateNormalizer;
 use Apigee\Edge\Normalizer\KeyValueMapNormalizer;
 use Apigee\Edge\Normalizer\ObjectNormalizer;
-use ArrayObject;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionMethod;
 use ReflectionObject;
@@ -91,7 +90,7 @@ class EntitySerializer implements EntitySerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|ArrayObject|null
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return $this->serializer->normalize($object, $format, $context);
     }
@@ -99,7 +98,7 @@ class EntitySerializer implements EntitySerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $this->format === $format && $this->serializer->supportsNormalization($data, $format);
     }
@@ -200,7 +199,7 @@ class EntitySerializer implements EntitySerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDecoding($format)
+    public function supportsDecoding($format): bool
     {
         return $this->format === $format && $this->serializer->supportsDecoding($format);
     }


### PR DESCRIPTION
Fixes #383 