### PR TITLE
Removed empty array option for CredentialProducts in AppCredential file due to strict Type

### DIFF
--- a/src/Api/Management/Entity/AppCredential.php
+++ b/src/Api/Management/Entity/AppCredential.php
@@ -37,9 +37,9 @@ class AppCredential extends Entity implements AppCredentialInterface
     use StatusPropertyAwareTrait;
 
     /**
-     * Array of credential products or an empty array.
+     * Array of credential products.
      *
-     * @var \Apigee\Edge\Structure\CredentialProduct[]|array
+     * @var \Apigee\Edge\Structure\CredentialProduct[]
      */
     protected $apiProducts = [];
 

--- a/tests/Serializer/EntitySerializerTest.php
+++ b/tests/Serializer/EntitySerializerTest.php
@@ -120,7 +120,8 @@ class EntitySerializerTest extends TestCase
         // Set value of this nullable value to ensure that a special condition is triggered in the EntityDenormalizer.
         $normalized->nullable = null;
         /** @var MockEntity $object */
-        $object = static::$serializer->denormalize($normalized, MockEntity::class);
+        $mockEntity = new MockEntity();
+        $object = static::$serializer->denormalize($normalized, $mockEntity::class);
         $this->assertTrue(true === $object->isBool());
         $this->assertTrue(2 === $object->getInt());
         $this->assertTrue(0 === $object->getZero());

--- a/tests/Serializer/EntitySerializerTest.php
+++ b/tests/Serializer/EntitySerializerTest.php
@@ -120,8 +120,7 @@ class EntitySerializerTest extends TestCase
         // Set value of this nullable value to ensure that a special condition is triggered in the EntityDenormalizer.
         $normalized->nullable = null;
         /** @var MockEntity $object */
-        $mockEntity = new MockEntity();
-        $object = static::$serializer->denormalize($normalized, $mockEntity::class);
+        $object = static::$serializer->denormalize($normalized, MockEntity::class);
         $this->assertTrue(true === $object->isBool());
         $this->assertTrue(2 === $object->getInt());
         $this->assertTrue(0 === $object->getZero());


### PR DESCRIPTION
Fixes #397 

In symfony 7, strict return type is expected as new TypeInfo is introduced.

returing stdClass instead of CredentialProduct class.