### PR TITLE
Removed PHP8.1 test from matrix for 4x

### DIFF
--- a/.github/workflows/php-test-workflow.yml
+++ b/.github/workflows/php-test-workflow.yml
@@ -11,8 +11,6 @@ jobs:
         strategy:
             matrix:
                 include:
-                -   php: '8.1'
-                    dependencies-preference: "--prefer-lowest"
                 -   php: '8.2'
                     dependencies-preference: " "
                 -   php: '8.2'


### PR DESCRIPTION
Removed test check with PHP 8.1 matrix as symfony 7 minimum requirement is 8.2