### PR TITLE
4x Fixes to make getter setter functions compatible with ctype_lower checks in symfony serializer component

### DIFF
--- a/src/Api/ApigeeX/Entity/BillingType.php
+++ b/src/Api/ApigeeX/Entity/BillingType.php
@@ -28,7 +28,7 @@ abstract class BillingType extends Entity implements BillingTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function getbillingType(): ?string
+    public function getBillingType(): ?string
     {
         return $this->billingType;
     }
@@ -38,7 +38,7 @@ abstract class BillingType extends Entity implements BillingTypeInterface
      *
      * @internal
      */
-    public function setbillingType(?string $billingType): void
+    public function setBillingType(?string $billingType): void
     {
         $this->billingType = $billingType;
     }

--- a/src/Api/ApigeeX/Entity/BillingTypeInterface.php
+++ b/src/Api/ApigeeX/Entity/BillingTypeInterface.php
@@ -25,10 +25,10 @@ interface BillingTypeInterface extends EntityInterface
     /**
      * @return string
      */
-    public function getbillingType(): ?string;
+    public function getBillingType(): ?string;
 
     /**
      * @param string|null $billingType
      */
-    public function setbillingType(?string $billingType): void;
+    public function setBillingType(?string $billingType): void;
 }

--- a/src/Api/ApigeeX/Entity/PrepaidBalance.php
+++ b/src/Api/ApigeeX/Entity/PrepaidBalance.php
@@ -47,7 +47,7 @@ class PrepaidBalance extends Entity implements PrepaidBalanceInterface
     /**
      * {@inheritdoc}
      */
-    public function getlastCreditTime(): ?string
+    public function getLastCreditTime(): ?string
     {
         return $this->lastCreditTime;
     }
@@ -55,7 +55,7 @@ class PrepaidBalance extends Entity implements PrepaidBalanceInterface
     /**
      * @param string $lastCreditTime
      */
-    public function setlastCreditTime(string $lastCreditTime): void
+    public function setLastCreditTime(string $lastCreditTime): void
     {
         $this->lastCreditTime = $lastCreditTime;
     }

--- a/src/Api/ApigeeX/Entity/PrepaidBalanceInterface.php
+++ b/src/Api/ApigeeX/Entity/PrepaidBalanceInterface.php
@@ -36,5 +36,5 @@ interface PrepaidBalanceInterface extends EntityInterface
     /**
      * @return string
      */
-    public function getlastCreditTime(): ?string;
+    public function getLastCreditTime(): ?string;
 }


### PR DESCRIPTION
Fixes #408 on 4.x