### PR TITLE
Update the symfony components to stable versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,8 @@
         "phpunit/phpunit": "^9.6",
         "sebastian/comparator": "^4.0.5",
         "symfony/cache": "^7.2.3",
+        "symfony/type-info": "^7.2.2",
+        "symfony/var-exporter": "^7.2.0",
         "vimeo/psalm": "^5.20"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,6 @@
         "phpunit/phpunit": "^9.6",
         "sebastian/comparator": "^4.0.5",
         "symfony/cache": "^7.2.3",
-        "symfony/type-info": "^7.2.2",
-        "symfony/var-exporter": "^7.2.0",
         "vimeo/psalm": "^5.20"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,9 @@
         "phpdocumentor/reflection-docblock": "^5.0",
         "psr/http-message": "^1.0 || ^2.0",
         "symfony/options-resolver": "^7.2.0",
-        "symfony/property-access": "^7.2.0",
-        "symfony/property-info": "^7.2.2",
-        "symfony/serializer": "^7.2.0"
+        "symfony/property-access": "^7.2.3",
+        "symfony/property-info": "^7.2.3",
+        "symfony/serializer": "^7.2.3"
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "^0.4.0",
@@ -46,7 +46,9 @@
         "phpmetrics/phpmetrics": "^2.7",
         "phpunit/phpunit": "^9.6",
         "sebastian/comparator": "^4.0.5",
-        "symfony/cache": "^7.2.1",
+        "symfony/cache": "^7.2.3",
+        "symfony/type-info": "^7.2.2",
+        "symfony/var-exporter": "^7.2.0",
         "vimeo/psalm": "^5.20"
     },
     "autoload": {


### PR DESCRIPTION
Fixes #411 

Symfony components version updated
property-access, property-info, serializer & cache to 7.2.3

New symfony components added in require-dev for test-cases as in prefer-lowest versions, they were using Symfony 5 & 6 versions, which was not compatible with the other symfony 7 lowest version
type-info to 7.2.2 & var-exporter to 7.2.0