### PR TITLE
support firebase/php-jwt ^7.0 | 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-openssl": "*",
         "ext-reflection": "*",
         "fightbulc/moment": "^1.26",
-        "firebase/php-jwt": "^6.0",
+        "firebase/php-jwt": "^7.0",
         "league/period": "^5.2",
         "php-http/client-common": "^2.0",
         "php-http/client-implementation": "^1.0",


### PR DESCRIPTION
security: upgrade firebase/php-jwt to latest v7.0.2

This update resolves the security vulnerability reported in [#1204](https://github.com/apigee/apigee-edge-drupal/issues/1204) regarding weak key validation. The library constraint is now expanded to support from v6 to v7.