### PR TITLE
Override testIgnoreVoidAccessor method

### DIFF
--- a/tests/PropertyAccess/PropertyAccessorDecoratorTest.php
+++ b/tests/PropertyAccess/PropertyAccessorDecoratorTest.php
@@ -205,12 +205,12 @@ class PropertyAccessorDecoratorTest extends PropertyAccessorTest
                 $shouldBeAString,
                 ['shouldBeAString', UnexpectedValueException::class, '/Invalid value returned for shouldBeAString property on instance of class@anonymous.* class. Expected type "string", got "stdClass".$/'],
             ];
-        } else {
-            return [
-                $shouldBeAString,
-                ['shouldBeAString', TypeError::class, '/Return value must be of type string, stdClass returned/'],
-            ];
         }
+
+        return [
+            $shouldBeAString,
+            ['shouldBeAString', TypeError::class, '/Return value must be of type string, stdClass returned/'],
+        ];
     }
 
     public function exceptionsToGetOnSetValue(): array
@@ -220,11 +220,11 @@ class PropertyAccessorDecoratorTest extends PropertyAccessorTest
             return [
                 ['shouldBeAStringArray', [null], InvalidArgumentException::class, '/^Expected argument of type "string", "null" given/'],
             ];
-        } else {
-            return [
-                ['shouldBeAStringArray', [null], TypeError::class, '/Argument #1 must be of type string, null given/'],
-            ];
         }
+
+        return [
+            ['shouldBeAStringArray', [null], TypeError::class, '/Argument #1 must be of type string, null given/'],
+        ];
     }
 
     /* * COMPATIBILITY OVERRIDES (PHPUnit 9+ vs Symfony 7.4+) *

--- a/tests/PropertyAccess/PropertyAccessorDecoratorTest.php
+++ b/tests/PropertyAccess/PropertyAccessorDecoratorTest.php
@@ -129,6 +129,18 @@ class PropertyAccessorDecoratorTest extends PropertyAccessorTest
     }
 
     /**
+     * Overrides the parent test method.
+     * Uses the DataProvider from the parent class.
+     *
+     * @dataProvider Symfony\Component\PropertyAccess\Tests\PropertyAccessorTest::voidAccessorProvider
+     */
+    public function testIgnoreVoidAccessor(string $property, mixed $value): void
+    {
+        // This assumes the test logic is also valid for your decorator.
+        parent::testIgnoreVoidAccessor($property, $value);
+    }
+
+    /**
      * @dataProvider exceptionsToGetOnGetValue
      */
     public function testGetValueWithInvalidReturns(string $property, string $expectedException, ?string $expectedExceptionMessageRegexp = null): void


### PR DESCRIPTION
Fix #460 
Override testIgnoreVoidAccessor to use parent class data provider.