### PR TITLE
 Resolved Developer test failure and Upgrade Symfony components to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "php-http/message-factory": "^1.0",
         "phpdocumentor/reflection-docblock": "^5.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "symfony/options-resolver": "^7.3.0",
-        "symfony/property-access": "^7.3.0",
-        "symfony/property-info": "^7.3.0",
+        "symfony/options-resolver": "^7.4.0",
+        "symfony/property-access": "^7.4.4",
+        "symfony/property-info": "^7.4.0",
         "symfony/serializer": "^7.3.0"
     },
     "require-dev": {

--- a/src/Api/Management/Controller/DeveloperController.php
+++ b/src/Api/Management/Controller/DeveloperController.php
@@ -111,29 +111,9 @@ class DeveloperController extends PaginatedEntityController implements Developer
         $uri = $this->getEntityEndpointUri($developer_entity->originalEmail());
         $response = $this->getClient()->put(
             $uri,
-            $this->getEntitySerializer()->serialize($developer_entity, 'json', ['ignored_attributes' => ['originalEmail']])
+            $this->getEntitySerializer()->serialize($developer_entity, 'json')
         );
         $this->getEntitySerializer()->setPropertiesFromResponse($response, $developer_entity);
-    }
-
-
-    /**
-     * Ensure 'originalEmail' is not included when creating developers.
-     *
-     * {@inheritdoc}
-     */
-    protected function buildEntityCreatePayload(EntityInterface $entity, array $context = []): string
-    {
-        if ($entity instanceof Developer) {
-            $ignored = $context['ignored_attributes'] ?? [];
-            $ignored[] = 'originalEmail';
-            $context['ignored_attributes'] = array_values(array_unique($ignored));
-        }
-
-        // The original implementation (from trait) simply delegates to the
-        // entity serializer. Mirror that behavior here while applying our
-        // adjusted context.
-        return $this->getEntitySerializer()->serialize($entity, 'json', $context);
     }
 
     /**

--- a/src/Api/Management/Controller/DeveloperController.php
+++ b/src/Api/Management/Controller/DeveloperController.php
@@ -111,9 +111,29 @@ class DeveloperController extends PaginatedEntityController implements Developer
         $uri = $this->getEntityEndpointUri($developer_entity->originalEmail());
         $response = $this->getClient()->put(
             $uri,
-            $this->getEntitySerializer()->serialize($developer_entity, 'json')
+            $this->getEntitySerializer()->serialize($developer_entity, 'json', ['ignored_attributes' => ['originalEmail']])
         );
         $this->getEntitySerializer()->setPropertiesFromResponse($response, $developer_entity);
+    }
+
+
+    /**
+     * Ensure 'originalEmail' is not included when creating developers.
+     *
+     * {@inheritdoc}
+     */
+    protected function buildEntityCreatePayload(EntityInterface $entity, array $context = []): string
+    {
+        if ($entity instanceof Developer) {
+            $ignored = $context['ignored_attributes'] ?? [];
+            $ignored[] = 'originalEmail';
+            $context['ignored_attributes'] = array_values(array_unique($ignored));
+        }
+
+        // The original implementation (from trait) simply delegates to the
+        // entity serializer. Mirror that behavior here while applying our
+        // adjusted context.
+        return $this->getEntitySerializer()->serialize($entity, 'json', $context);
     }
 
     /**

--- a/src/PropertyAccess/PropertyAccessorDecorator.php
+++ b/src/PropertyAccess/PropertyAccessorDecorator.php
@@ -60,6 +60,7 @@ final class PropertyAccessorDecorator implements PropertyAccessorInterface
             // Auto-retry, try to pass the value as variable-length arguments to
             // the setter method.
             if (is_object($objectOrArray) && is_array($value)) {
+                /** @var object $objectOrArray */
                 $setter = null;
                 // Support setPropertyName() and propertyName() setters.
                 foreach (['set' . ucfirst((string) $propertyPath), (string) $propertyPath] as $methodName) {

--- a/tests/Api/Management/Controller/DeveloperControllerTest.php
+++ b/tests/Api/Management/Controller/DeveloperControllerTest.php
@@ -37,6 +37,7 @@ use Apigee\Edge\Tests\Test\Controller\MockClientAwareTrait;
 use Apigee\Edge\Tests\Test\TestClientFactory;
 use Apigee\Edge\Tests\Test\Utility\MarkOnlineTestSkippedAwareTrait;
 use GuzzleHttp\Psr7\Response;
+use Composer\InstalledVersions;
 
 /**
  * Class DeveloperControllerTest.
@@ -61,7 +62,7 @@ class DeveloperControllerTest extends EntityControllerTestBase
     use PaginatedEntityIdListingControllerTestTrait;
     use PaginatedEntityListingControllerTestTrait;
     use AttributesAwareEntityControllerTestTrait;
-
+    
     /**
      * @group online
      */
@@ -179,5 +180,58 @@ class DeveloperControllerTest extends EntityControllerTestBase
     protected static function entityCreateOperationTestController(): EntityCreateOperationTestControllerTesterInterface
     {
         return new EntityCreateOperationControllerTester(static::entityController());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function alterArraysBeforeCompareSentAndReceivedPayloadsInCreate(array &$sentEntityAsArray, array $responseEntityAsArray): void
+    {
+        // Get the version string (e.g., "6.4.12")
+        $version = InstalledVersions::getVersion('symfony/serializer');
+        if (version_compare($version, '7.3.11', '>=')) {
+            // The originalEmail property is not returned by the API on creation.
+            unset($sentEntityAsArray['originalEmail']);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function alterObjectsBeforeCompareResponseAndCreatedEntity(\stdClass &$responseObject, \Apigee\Edge\Entity\EntityInterface $created): void
+    {
+        $version = InstalledVersions::getVersion('symfony/serializer');
+        if (version_compare($version, '7.3.11', '>=')) {
+            // The originalEmail property is not returned by the API on creation.
+            if ($created instanceof \Apigee\Edge\Api\Management\Entity\Developer) {
+                $responseObject->originalEmail = $created->originalEmail();
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function alterArraysBeforeCompareSentAndReceivedPayloadsInUpdate(array &$sentEntityAsArray, array $responseEntityAsArray): void
+    {
+        $version = InstalledVersions::getVersion('symfony/serializer');
+        if (version_compare($version, '7.3.11', '>=')) {
+            // The originalEmail property is not returned by the API on update.
+            unset($sentEntityAsArray['originalEmail']);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function alterObjectsBeforeCompareResponseAndUpdateEntity(\stdClass &$responseObject, \Apigee\Edge\Entity\EntityInterface $updated): void
+    {
+        $version = InstalledVersions::getVersion('symfony/serializer');
+        if (version_compare($version, '7.3.11', '>=')) {
+            // The originalEmail property is not returned by the API on update.
+            if ($updated instanceof \Apigee\Edge\Api\Management\Entity\Developer) {
+                $responseObject->originalEmail = $updated->originalEmail();
+            }
+        }
     }
 }

--- a/tests/Api/Management/Controller/DeveloperControllerTest.php
+++ b/tests/Api/Management/Controller/DeveloperControllerTest.php
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,8 +36,9 @@ use Apigee\Edge\Tests\Test\Controller\EntityUpdateOperationControllerTestTrait;
 use Apigee\Edge\Tests\Test\Controller\MockClientAwareTrait;
 use Apigee\Edge\Tests\Test\TestClientFactory;
 use Apigee\Edge\Tests\Test\Utility\MarkOnlineTestSkippedAwareTrait;
-use GuzzleHttp\Psr7\Response;
 use Composer\InstalledVersions;
+use GuzzleHttp\Psr7\Response;
+use stdClass;
 
 /**
  * Class DeveloperControllerTest.
@@ -62,7 +63,7 @@ class DeveloperControllerTest extends EntityControllerTestBase
     use PaginatedEntityIdListingControllerTestTrait;
     use PaginatedEntityListingControllerTestTrait;
     use AttributesAwareEntityControllerTestTrait;
-    
+
     /**
      * @group online
      */
@@ -198,12 +199,12 @@ class DeveloperControllerTest extends EntityControllerTestBase
     /**
      * {@inheritdoc}
      */
-    protected function alterObjectsBeforeCompareResponseAndCreatedEntity(\stdClass &$responseObject, \Apigee\Edge\Entity\EntityInterface $created): void
+    protected function alterObjectsBeforeCompareResponseAndCreatedEntity(stdClass &$responseObject, EntityInterface $created): void
     {
         $version = InstalledVersions::getVersion('symfony/serializer');
         if (version_compare($version, '7.3.11', '>=')) {
             // The originalEmail property is not returned by the API on creation.
-            if ($created instanceof \Apigee\Edge\Api\Management\Entity\Developer) {
+            if ($created instanceof Developer) {
                 $responseObject->originalEmail = $created->originalEmail();
             }
         }
@@ -224,12 +225,12 @@ class DeveloperControllerTest extends EntityControllerTestBase
     /**
      * {@inheritdoc}
      */
-    protected function alterObjectsBeforeCompareResponseAndUpdateEntity(\stdClass &$responseObject, \Apigee\Edge\Entity\EntityInterface $updated): void
+    protected function alterObjectsBeforeCompareResponseAndUpdateEntity(stdClass &$responseObject, EntityInterface $updated): void
     {
         $version = InstalledVersions::getVersion('symfony/serializer');
         if (version_compare($version, '7.3.11', '>=')) {
             // The originalEmail property is not returned by the API on update.
-            if ($updated instanceof \Apigee\Edge\Api\Management\Entity\Developer) {
+            if ($updated instanceof Developer) {
                 $responseObject->originalEmail = $updated->originalEmail();
             }
         }


### PR DESCRIPTION
Fixed a regression in `DeveloperControllerTest` caused by the missing 'originalEmail' field in the API response by adjusting the test comparison logic for serializer versions >= 7.3.11. Upgraded property-access, options-resolver, and property-info to 7.4. 

Fix: PR #466 