### PR TITLE
Ignore 'originalEmail' when creating developer entities

### DIFF
--- a/src/Api/Management/Controller/DeveloperController.php
+++ b/src/Api/Management/Controller/DeveloperController.php
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -111,9 +111,28 @@ class DeveloperController extends PaginatedEntityController implements Developer
         $uri = $this->getEntityEndpointUri($developer_entity->originalEmail());
         $response = $this->getClient()->put(
             $uri,
-            $this->getEntitySerializer()->serialize($developer_entity, 'json')
+            $this->getEntitySerializer()->serialize($developer_entity, 'json', ['ignored_attributes' => ['originalEmail']])
         );
         $this->getEntitySerializer()->setPropertiesFromResponse($response, $developer_entity);
+    }
+
+    /**
+     * Ensure 'originalEmail' is not included when creating developers.
+     *
+     * {@inheritdoc}
+     */
+    protected function buildEntityCreatePayload(EntityInterface $entity, array $context = []): string
+    {
+        if ($entity instanceof Developer) {
+            $ignored = $context['ignored_attributes'] ?? [];
+            $ignored[] = 'originalEmail';
+            $context['ignored_attributes'] = array_values(array_unique($ignored));
+        }
+
+        // The original implementation (from trait) simply delegates to the
+        // entity serializer. Mirror that behavior here while applying our
+        // adjusted context.
+        return $this->getEntitySerializer()->serialize($entity, 'json', $context);
     }
 
     /**


### PR DESCRIPTION
Updated the serialization process to ignore 'originalEmail' when creating developers. Adjusted the context for entity creation to ensure 'originalEmail' is not included.